### PR TITLE
Fix spiral canvas sizing using inner window dimensions

### DIFF
--- a/apps/harmonic-mixer/sketch.js
+++ b/apps/harmonic-mixer/sketch.js
@@ -105,7 +105,10 @@ function updateMasterAutoScale(ms = RAMP_MS) {
 
 // ---------- Setup ----------
 window.setup = function () {
-  createCanvas(windowWidth, windowHeight);   // fill viewport
+  // Use the browser's inner dimensions to size the canvas. In some module
+  // contexts, p5's windowWidth/windowHeight globals can be undefined, which
+  // results in a zero-sized drawing surface and the spiral not appearing.
+  createCanvas(window.innerWidth, window.innerHeight);   // fill viewport
   pixelDensity(2);
   strokeCap(ROUND);
   textFont('system-ui, -apple-system, Segoe UI, Roboto, sans-serif');
@@ -121,7 +124,8 @@ window.setup = function () {
 };
 
 window.windowResized = function () {
-  resizeCanvas(windowWidth, windowHeight);
+  // Keep the canvas in sync with the viewport if it changes size.
+  resizeCanvas(window.innerWidth, window.innerHeight);
 };
 
 window.draw = function () {


### PR DESCRIPTION
## Summary
- use `window.innerWidth`/`innerHeight` to size and resize canvas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adea2a8ea08320ac979ee547963233