### PR TITLE
Add view mode tabs for Harmonic Mixer

### DIFF
--- a/apps/harmonic-mixer/styles.css
+++ b/apps/harmonic-mixer/styles.css
@@ -53,6 +53,25 @@ canvas{
   overflow-x: hidden;
 }
 
+/* View tabs */
+.view-tabs{
+  display:flex;
+  justify-content:center;
+  gap:8px;
+}
+.view-tab{
+  padding:4px 12px;
+  border:1px solid var(--panel-border);
+  border-radius:8px;
+  background:#1a1a1f;
+  cursor:pointer;
+  user-select:none;
+}
+.view-tab.active{
+  background:var(--accent);
+  color:#000;
+}
+
 /* Groups */
 .group{
   display:flex;
@@ -101,7 +120,7 @@ canvas{
   border: 0;
   box-shadow: 0 0 0 3px #00000033;
 }
-select, .play-btn { font: inherit; }
+select, .play-btn, .view-tab { font: inherit; }
 
 /* Play button */
 .play-btn{


### PR DESCRIPTION
## Summary
- Add view-mode tabs to toggle between Spiral View and Component View in the harmonic mixer controls
- Render spiral only when Spiral View tab is active; Component View currently blank
- Style tabs and highlight the active selection

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0376baf1c8320aeafe167ea0e989c