### PR TITLE
Add view mode tabs and component view for Harmonic Mixer

### DIFF
--- a/apps/harmonic-mixer/sketch.js
+++ b/apps/harmonic-mixer/sketch.js
@@ -32,12 +32,13 @@ let playing = false;
 let tempo = DEFAULT_TEMPO;
 let seqIndex = 0;
 let seqNextTime = 0;
+let viewMode = 'spiral'; // 'spiral' | 'components'
 
 const auditioning = Array(PARTIALS).fill(false);
 const replacing   = Array(PARTIALS).fill(false);
 
 // p5 + UI
-let ui, groupGlobal, groupGrid, playGroup;
+let ui, tabContainer, tabSpiral, tabComponents, groupGlobal, groupGrid, playGroup;
 let f0Slider, masterSlider, curveCheckbox, modeSelect, tempoSlider, tempoRow, playBtn;
 let colSliders = [];
 let colHzLabels = [];
@@ -132,65 +133,111 @@ window.windowResized = function () {
 window.draw = function () {
   background(11);
 
-  // Spiral bounds: square occupying 80% of the smaller canvas dimension.
-  const boundSide = 0.8 * Math.min(width, height);
-  const maxRadiusPixels = Math.max(0, boundSide / 2);
+  if (viewMode === 'spiral') {
+    // Spiral bounds: square occupying 80% of the smaller canvas dimension.
+    const boundSide = 0.8 * Math.min(width, height);
+    const maxRadiusPixels = Math.max(0, boundSide / 2);
 
-  // Center of the canvas
-  const cx = Math.floor(width / 2);
-  const cy = Math.floor(height / 2);
+    // Center of the canvas
+    const cx = Math.floor(width / 2);
+    const cy = Math.floor(height / 2);
 
+    // Compute scale so the OUTERMOST radius (k = PARTIALS) fits within the bounds
+    const finalUnscaledR  = X_BASE * PARTIALS; // outer radius before scaling
+    const s = finalUnscaledR > 0 ? (maxRadiusPixels / finalUnscaledR) : 0;
 
-  // Compute scale so the OUTERMOST radius (k = PARTIALS) fits within the bounds
-  const finalUnscaledR  = X_BASE * PARTIALS; // outer radius before scaling
-  const s = finalUnscaledR > 0 ? (maxRadiusPixels / finalUnscaledR) : 0;
+    push();
+    translate(cx, cy);
 
-  push();
-  translate(cx, cy);
-
-  if (s > 0 && showCurve) {
-    // Spiral curve
-    const thetaMax = TAU * Math.log2(PARTIALS);
-    noFill(); stroke(70); strokeWeight(2);
-    beginShape();
-    for (let th = 0; th <= thetaMax; th += 0.02) {
-      const r = X_BASE * Math.pow(2, th / TAU) * s;
-      vertex(r * Math.cos(th), r * Math.sin(th));
+    if (s > 0 && showCurve) {
+      // Spiral curve
+      const thetaMax = TAU * Math.log2(PARTIALS);
+      noFill(); stroke(70); strokeWeight(2);
+      beginShape();
+      for (let th = 0; th <= thetaMax; th += 0.02) {
+        const r = X_BASE * Math.pow(2, th / TAU) * s;
+        vertex(r * Math.cos(th), r * Math.sin(th));
+      }
+      endShape();
     }
-    endShape();
-  }
 
-  if (s > 0) {
-    // Axes
-    stroke(50); strokeWeight(1);
-    line(-boundSide/2, 0, boundSide/2, 0);
-    line(0, -boundSide/2, 0, boundSide/2);
+    if (s > 0) {
+      // Axes
+      stroke(50); strokeWeight(1);
+      line(-boundSide/2, 0, boundSide/2, 0);
+      line(0, -boundSide/2, 0, boundSide/2);
 
-    // Partials
+      // Partials
+      for (let i = 0; i < PARTIALS; i++) {
+        const k = i + 1;
+        const th = Math.log2(k) * TAU;
+        const r  = (k * X_BASE) * s;
+        const px = r * Math.cos(th);
+        const py = r * Math.sin(th);
+
+        const g = gains[i];
+        const alpha = g / PARTIAL_MAX;
+        const col = color(220, 210, 140, 255 * alpha);
+
+        stroke(red(col), green(col), blue(col), alpha * 255); strokeWeight(2);
+        line(0, 0, px, py);
+
+        noStroke(); fill(red(col), green(col), blue(col), alpha * 255);
+        circle(px, py, 8);
+
+        fill(210, 210, 210, 220); textSize(12); textAlign(CENTER, CENTER);
+        const off = 16;
+        text(`${k}`, px + off * Math.cos(th), py + off * Math.sin(th));
+      }
+    }
+
+    pop();
+  } else if (viewMode === 'components') {
+    // Circle for angles on the left half
+    const circleRadius = Math.min(width * 0.25, height * 0.45);
+    const cx = width * 0.25;
+    const cy = height / 2;
+
+    noFill(); stroke(70); strokeWeight(2); circle(cx, cy, circleRadius * 2);
+
     for (let i = 0; i < PARTIALS; i++) {
       const k = i + 1;
       const th = Math.log2(k) * TAU;
-      const r  = (k * X_BASE) * s;
-      const px = r * Math.cos(th);
-      const py = r * Math.sin(th);
-
       const g = gains[i];
       const alpha = g / PARTIAL_MAX;
+      if (alpha <= 0) continue;
       const col = color(220, 210, 140, 255 * alpha);
-
+      const px = cx + circleRadius * Math.cos(th);
+      const py = cy + circleRadius * Math.sin(th);
       stroke(red(col), green(col), blue(col), alpha * 255); strokeWeight(2);
-      line(0, 0, px, py);
+      line(cx, cy, px, py);
+      noStroke(); fill(red(col), green(col), blue(col), alpha * 255); circle(px, py, 8);
+    }
 
-      noStroke(); fill(red(col), green(col), blue(col), alpha * 255);
-      circle(px, py, 8);
+    // Vertical lines for lengths on the right half
+    const rightLeft = width / 2;
+    const rightWidth = width / 2;
+    const spacing = rightWidth / (PARTIALS + 1);
+    const baseY = height * 0.9;
+    const maxLenPixels = height * 0.8;
+    const sLen = maxLenPixels / (PARTIALS * X_BASE);
 
-      fill(210, 210, 210, 220); textSize(12); textAlign(CENTER, CENTER);
-      const off = 16;
-      text(`${k}`, px + off * Math.cos(th), py + off * Math.sin(th));
+    stroke(50); strokeWeight(1); line(rightLeft, baseY, width, baseY);
+
+    for (let i = 0; i < PARTIALS; i++) {
+      const k = i + 1;
+      const len = k * X_BASE * sLen;
+      const x = rightLeft + spacing * (i + 1);
+      const yTop = baseY - len;
+      const g = gains[i];
+      const alpha = g / PARTIAL_MAX;
+      if (alpha <= 0) continue;
+      const col = color(220, 210, 140, 255 * alpha);
+      stroke(red(col), green(col), blue(col), alpha * 255); strokeWeight(2);
+      line(x, baseY, x, yTop);
+      noStroke(); fill(red(col), green(col), blue(col), alpha * 255); circle(x, yTop, 8);
     }
   }
-
-  pop();
 
   if (playing && mode === 'seq' && ctx) stepSequenceIfDue();
 };
@@ -211,7 +258,24 @@ function updateGridUI() {
 function buildUI() {
   ui = createDiv().addClass('ui');
 
-  // Play group (now first)
+  // View tabs
+  tabContainer = createDiv().addClass('view-tabs');
+  tabSpiral = createSpan('Spiral View').addClass('view-tab').addClass('active');
+  tabComponents = createSpan('Component View').addClass('view-tab');
+  tabContainer.child(tabSpiral);
+  tabContainer.child(tabComponents);
+  tabSpiral.mousePressed(() => {
+    viewMode = 'spiral';
+    tabSpiral.addClass('active');
+    tabComponents.removeClass('active');
+  });
+  tabComponents.mousePressed(() => {
+    viewMode = 'components';
+    tabComponents.addClass('active');
+    tabSpiral.removeClass('active');
+  });
+
+  // Play group
   playGroup = createDiv().addClass('group');
   playBtn = createButton('▶'); playBtn.addClass('play-btn'); playBtn.attribute('title', 'Play/Pause');
   playGroup.child(playBtn);
@@ -312,7 +376,8 @@ function buildUI() {
     }
   });
 
-  // ORDER: Play first, then Global, then Grid
+  // ORDER: Tabs, Play, Global, then Grid
+  ui.child(tabContainer);
   ui.child(playGroup);
   ui.child(groupGlobal);
   ui.child(groupGrid);

--- a/apps/harmonic-mixer/styles.css
+++ b/apps/harmonic-mixer/styles.css
@@ -53,6 +53,25 @@ canvas{
   overflow-x: hidden;
 }
 
+/* View tabs */
+.view-tabs{
+  display:flex;
+  justify-content:center;
+  gap:8px;
+}
+.view-tab{
+  padding:4px 12px;
+  border:1px solid var(--panel-border);
+  border-radius:8px;
+  background:#1a1a1f;
+  cursor:pointer;
+  user-select:none;
+}
+.view-tab.active{
+  background:var(--accent);
+  color:#000;
+}
+
 /* Groups */
 .group{
   display:flex;
@@ -101,7 +120,7 @@ canvas{
   border: 0;
   box-shadow: 0 0 0 3px #00000033;
 }
-select, .play-btn { font: inherit; }
+select, .play-btn, .view-tab { font: inherit; }
 
 /* Play button */
 .play-btn{


### PR DESCRIPTION
## Summary
- Add view-mode tabs to toggle between Spiral View and Component View in the harmonic mixer controls
- Render spiral only when Spiral View tab is active
- Draw Component View split into angle and length representations with visibility tied to harmonic gains

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0376baf1c8320aeafe167ea0e989c