### PR TITLE
Clarify component view and color-code partial sliders

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Highlights:
 - Sequence mode: step through partials one by one at a chosen tempo.
 - Audition a single partial while adjusting its slider.
 - Smooth gain transitions to avoid clicks.
+- Slider knobs match each partial's color for quick visual association.
 
 ## Getting Started
 1. Clone this repository.

--- a/apps/harmonic-mixer/sketch.js
+++ b/apps/harmonic-mixer/sketch.js
@@ -287,11 +287,14 @@ window.draw = function () {
     }
 
     pop();
-    drawLabelBox(cx, cy + circleR + 16, 'Angle');
+    drawLabelBox(cx, cy + circleR + 24, 'Angle');
 
     // ----- Right: lengths as vertical lines -----
     const baseY = cy + circleR;
     const colWidth = halfWidth / PARTIALS;
+
+    // Base line for lengths
+    stroke(50); strokeWeight(1); line(halfWidth, baseY, width, baseY);
 
     for (let i = PARTIALS - 1; i >= 0; i--) {
       const k = i + 1;
@@ -312,7 +315,7 @@ window.draw = function () {
       circle(x, yTop, terminalCircleSize(k));
     }
 
-    drawLabelBox(halfWidth + halfWidth / 2, baseY + 16, 'Length');
+    drawLabelBox(halfWidth + halfWidth / 2, baseY + 24, 'Length');
   }
 
   if (playing && mode === 'seq' && ctx) stepSequenceIfDue();
@@ -419,7 +422,9 @@ function buildUI() {
     const k = i + 1;
     const col = createDiv().addClass('hcol');
     const label = createSpan('k=' + k);
+    const [rCol, gCol, bCol] = octaveColor(k);
     const v = createSlider(0, 100, Math.round((gains[i] / PARTIAL_MAX) * 100), 1); v.addClass('vslider');
+    v.style('--accent', `rgb(${rCol}, ${gCol}, ${bCol})`);
     const hz = createSpan('').addClass('hz');
     col.child(label); col.child(v); col.child(hz);
     grid.child(col);


### PR DESCRIPTION
## Summary
- Drop component labels slightly and add a baseline under length lines for clearer interpretation
- Tint each partial's volume slider knob with its corresponding line color
- Document slider color-coding in the Harmonic Mixer README section

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/log-spiral/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b070c476b883209f88187128f6c997