### PR TITLE
Fix per-partial slider colors

### DIFF
--- a/apps/harmonic-mixer/sketch.js
+++ b/apps/harmonic-mixer/sketch.js
@@ -424,7 +424,9 @@ function buildUI() {
     const label = createSpan('k=' + k);
     const [rCol, gCol, bCol] = octaveColor(k);
     const v = createSlider(0, 100, Math.round((gains[i] / PARTIAL_MAX) * 100), 1); v.addClass('vslider');
-    v.style('--accent', `rgb(${rCol}, ${gCol}, ${bCol})`);
+    const color = `rgb(${rCol}, ${gCol}, ${bCol})`;
+    v.elt.style.setProperty('--accent', color);
+    v.elt.style.setProperty('accent-color', color);
     const hz = createSpan('').addClass('hz');
     col.child(label); col.child(v); col.child(hz);
     grid.child(col);

--- a/apps/harmonic-mixer/styles.css
+++ b/apps/harmonic-mixer/styles.css
@@ -168,6 +168,7 @@ select, .play-btn, .view-tab { font: inherit; }
   background: linear-gradient(#2a2a31, #2a2a31) no-repeat center/5px 100%;
   border-radius: 10px;
   outline:none;
+  accent-color: var(--accent);
 }
 .vslider::-webkit-slider-thumb{
   -webkit-appearance: none;


### PR DESCRIPTION
## Summary
- ensure each harmonic mixer's slider thumb is colored to match its partial
- expose slider accent color via CSS accent-color for broader browser support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b07363b1c4832098e0ec1e878d6310