### PR TITLE
Improve spiral partial labels in harmonic-mixer

### DIFF
--- a/apps/harmonic-mixer/sketch.js
+++ b/apps/harmonic-mixer/sketch.js
@@ -75,6 +75,33 @@ function drawLabelBox(x, y, label) {
   pop();
 }
 
+function drawPartialLabel(px, py, label, k) {
+  push();
+  const PAD = 4;
+  const TS = 12;
+  textSize(TS);
+
+  // Uniform box sized for up to two-digit labels
+  const boxW = textWidth('16') + PAD * 2;
+  const boxH = TS + PAD * 2;
+
+  // Offset label outward from the terminal point along its radial direction
+  const circleR = terminalCircleSize(k) / 2;
+  const offset = circleR + 4 + boxH / 2;
+  const ang = Math.atan2(py, px);
+  const x = px + Math.cos(ang) * offset;
+  const y = py + Math.sin(ang) * offset;
+
+  rectMode(CENTER);
+  noStroke();
+  fill(20, 20, 25, 220);
+  rect(x, y, boxW, boxH, 4);
+  fill(210, 210, 210, 220);
+  textAlign(CENTER, CENTER);
+  text(label, x, y);
+  pop();
+}
+
 // ---------- State ----------
 let f0 = DEFAULT_F0;
 let gains = Array(PARTIALS).fill(0); gains[0] = 1 * PARTIAL_MAX;
@@ -238,10 +265,7 @@ window.draw = function () {
         noStroke();
         fill(rCol, gCol, bCol, alpha * 255);
         circle(px, py, terminalCircleSize(k));
-
-        fill(210, 210, 210, 220); textSize(12); textAlign(CENTER, CENTER);
-        const off = 16;
-        text(`${k}`, px + off * Math.cos(th), py + off * Math.sin(th));
+        drawPartialLabel(px, py, `${k}`, k);
       }
     }
 


### PR DESCRIPTION
## Summary
- offset label placement along radial direction to keep number boxes clear of partial lines

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b072ec532c8320ad3274e8322b45bb