### PR TITLE
Offset partial labels to avoid intersecting lines

### DIFF
--- a/apps/harmonic-mixer/sketch.js
+++ b/apps/harmonic-mixer/sketch.js
@@ -85,11 +85,20 @@ function drawPartialLabel(px, py, label, k) {
   const boxW = textWidth('16') + PAD * 2;
   const boxH = TS + PAD * 2;
 
-  // Position label below the terminal point
+  // Offset label away from the radial line to avoid overlaps
   const circleR = terminalCircleSize(k) / 2;
-  const offsetY = circleR + 4 + boxH / 2;
-  const x = px;
-  const y = py + offsetY;
+  const radialOffset = circleR + 4;
+  const tangentialOffset = boxH / 2 + 4;
+
+  // Determine radial and tangential directions for the partial
+  const angle = Math.atan2(py, px);
+  const ux = Math.cos(angle);
+  const uy = Math.sin(angle);
+  const tx = -uy;
+  const ty = ux;
+
+  const x = px + ux * radialOffset + tx * tangentialOffset;
+  const y = py + uy * radialOffset + ty * tangentialOffset;
 
   rectMode(CENTER);
   noStroke();


### PR DESCRIPTION
## Summary
- Shift harmonic partial number labels away from radial lines
- Calculate label offset using radial and tangential vectors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b076d559208320b528f58c702c0d60