### PR TITLE
Fix harmonic-mixer playback and spiral rendering issues

### DIFF
--- a/apps/harmonic-mixer/audio.js
+++ b/apps/harmonic-mixer/audio.js
@@ -236,6 +236,7 @@ export function updateRouteForMode() {
 
 // ----- Smooth Play/Pause -----
 export function smoothStartMix() {
+  ensureAudio();
   playing = true;
   const t = audioNow();
   setNow(masterGain.gain, 0);
@@ -256,6 +257,7 @@ export function smoothStartMix() {
 }
 
 export function smoothStartSequence() {
+  ensureAudio();
   playing = true;
   resetSequenceClock();
   const t = audioNow();
@@ -269,12 +271,15 @@ export function smoothStartSequence() {
 }
 
 export function smoothPauseAll() {
+  ensureAudio();
+  playing = false;
   const t = audioNow();
   applyCurve(masterGain.gain, masterGain.gain.value, 0, MASTER_FADE_MS, t);
   setTimeout(() => {
     const t2 = audioNow();
-    for (let i = 0; i < PARTIALS; i++) applyCurve(routeGains[i].gain, routeGains[i].gain.value, 0, RAMP_MS, t2);
-    playing = false;
+    for (let i = 0; i < PARTIALS; i++) {
+      applyCurve(routeGains[i].gain, routeGains[i].gain.value, 0, RAMP_MS, t2);
+    }
   }, MASTER_FADE_MS + 12);
 }
 
@@ -293,11 +298,13 @@ export function stepSequenceIfDue() {
 
   if (seqIndex >= PARTIALS) {
     const t = audioNow();
+    playing = false;
     applyCurve(masterGain.gain, masterGain.gain.value, 0, MASTER_FADE_MS, t);
     setTimeout(() => {
       const t2 = audioNow();
-      for (let i = 0; i < PARTIALS; i++) applyCurve(routeGains[i].gain, routeGains[i].gain.value, 0, RAMP_MS, t2);
-      playing = false;
+      for (let i = 0; i < PARTIALS; i++) {
+        applyCurve(routeGains[i].gain, routeGains[i].gain.value, 0, RAMP_MS, t2);
+      }
     }, MASTER_FADE_MS + 12);
     return;
   }

--- a/apps/harmonic-mixer/drawing.js
+++ b/apps/harmonic-mixer/drawing.js
@@ -55,18 +55,14 @@ export function drawLabelBox(x, y, label) {
 
 export function drawPartialLabel(px, py, label, k) {
   push();
-  const PAD = 4;
   const TS = 12;
   textSize(TS);
 
-  // Uniform box sized for up to two-digit labels
-  const boxW = textWidth('16') + PAD * 2;
-  const boxH = TS + PAD * 2;
-
   // Offset label away from the radial line to avoid overlaps
   const circleR = terminalCircleSize(k) / 2;
-  const radialOffset = circleR + 4;
-  const tangentialOffset = boxH / 2 + 4;
+  const isPowerOfTwo = (k & (k - 1)) === 0;
+  const radialOffset = isPowerOfTwo ? 0 : circleR + 4;
+  const tangentialOffset = TS / 2 + 4;
 
   // Determine radial and tangential directions for the partial
   const angle = Math.atan2(py, px);
@@ -78,10 +74,7 @@ export function drawPartialLabel(px, py, label, k) {
   const x = px + ux * radialOffset + tx * tangentialOffset;
   const y = py + uy * radialOffset + ty * tangentialOffset;
 
-  rectMode(CENTER);
   noStroke();
-  fill(20, 20, 25, 220);
-  rect(x, y, boxW, boxH, 4);
   fill(210, 210, 210, 220);
   textAlign(CENTER, CENTER);
   text(label, x, y);
@@ -100,7 +93,7 @@ export function drawSpiralCurve(s) {
 }
 
 export function drawPartials(s) {
-  for (let i = 0; i < PARTIALS; i++) {
+  for (let i = PARTIALS - 1; i >= 0; i--) {
     const k = i + 1;
     const th = (Math.log2(k)) * TAU;
     const r = (k * X_BASE) * s;


### PR DESCRIPTION
## Summary
- Resume audio on play and pause to ensure sound starts on first click
- Update play state logic to restore play icon after pausing
- Draw lower partials on top and realign spiral labels without boxes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b07edeab548320bd4ad8b30638f5b4