### PR TITLE
Fix angle label overlap and mobile controls

### DIFF
--- a/apps/harmonic-mixer/sketch.js
+++ b/apps/harmonic-mixer/sketch.js
@@ -150,9 +150,12 @@ window.draw = function () {
       const h = lineHeight * lines.length;
 
       if (sorted.length > 1) {
-        // Ensure label stays outside the circle and partial lines
+        // Ensure the label's bounding box stays outside the circle.
+        // Use the radius of a bounding circle (covers width & height)
+        // so labels like "[5, 10]" don't intersect the edge.
         const dist = Math.sqrt(x * x + y * y);
-        const minDist = circleR + w / 2 + 4;
+        const rLabel = Math.sqrt(w * w + h * h) / 2;
+        const minDist = circleR + rLabel + 4;
         if (dist < minDist) {
           const extra = minDist - dist;
           x += Math.cos(th) * extra;

--- a/apps/harmonic-mixer/styles.css
+++ b/apps/harmonic-mixer/styles.css
@@ -80,6 +80,7 @@ canvas{
   padding: 4px 6px;
   border-radius: 10px;
   border:1px solid transparent;
+  flex-wrap: wrap;
 }
 .group:focus-within{
   border-color: #2d2d34;
@@ -93,7 +94,8 @@ canvas{
   margin-right: 2px;
   text-transform: uppercase;
 }
-.nowrap{ display:flex; align-items:center; gap:6px; white-space:nowrap; }
+.control-row{ display:flex; align-items:center; gap:6px; flex-wrap:nowrap; white-space:nowrap; }
+.mode-row{ display:flex; align-items:center; gap:6px; flex-wrap:wrap; }
 
 .group span{ user-select:none; }
 .group .label{ font-weight:600; color: var(--muted); margin-right: 4px; }
@@ -231,7 +233,10 @@ select, .play-btn, .view-tab { font: inherit; }
   .vslider{ height: 10vh; width: 20px; }
   .title{ font-size:10px; }
 }
-@media (max-width: 380px){
-  .slider{ width:110px; }
+@media (max-width: 480px){
+  .slider{ width:100px; }
+}
+@media (max-width: 360px){
+  .slider{ width:80px; }
   .vslider{ height: 9vh; width: 18px; }
 }

--- a/apps/harmonic-mixer/ui.js
+++ b/apps/harmonic-mixer/ui.js
@@ -62,28 +62,31 @@ export function buildUI() {
   // Global settings
   groupGlobal = createDiv().addClass('group');
 
-  groupGlobal.child(makeLabel('f₀ (Hz):'));
+  const f0Row = createDiv().addClass('control-row');
+  f0Row.child(makeLabel('f₀ (Hz):'));
   f0Slider = createSlider(80, 160, DEFAULT_F0, 1); f0Slider.addClass('slider');
   const f0Val = createSpan('').style('color', '#cfcfcf');
-  groupGlobal.child(f0Slider); groupGlobal.child(f0Val);
+  f0Row.child(f0Slider); f0Row.child(f0Val);
+  groupGlobal.child(f0Row);
   f0Slider.elt.addEventListener('input', () => {
     setF0(parseInt(f0Slider.value(), 10));
     f0Val.html(' ' + getF0() + ' Hz');
     updateGridUI();
   });
 
-  groupGlobal.child(makeLabel('Master:'));
+  const masterRow = createDiv().addClass('control-row');
+  masterRow.child(makeLabel('Master:'));
   masterSlider = createSlider(0, 100, Math.round(DEFAULT_MASTER * 100), 1); masterSlider.addClass('slider');
   const mVal = createSpan('').style('color', '#cfcfcf');
-  groupGlobal.child(masterSlider); groupGlobal.child(mVal);
+  masterRow.child(masterSlider); masterRow.child(mVal);
+  groupGlobal.child(masterRow);
   masterSlider.elt.addEventListener('input', () => {
     setMasterUI(parseInt(masterSlider.value(), 10) / 100);
     updateMasterAutoScale();
     mVal.html(' ' + Math.round(masterSlider.value()) + '%');
   });
 
-
-  const modeRow = createDiv().addClass('nowrap');
+  const modeRow = createDiv().addClass('mode-row');
   const togetherLabel = createSpan('Play Together');
   const modeToggle = createDiv().addClass('mode-toggle');
   const modeKnob = createDiv().addClass('mode-knob');
@@ -106,7 +109,7 @@ export function buildUI() {
     updateModeToggle();
   });
 
-  tempoRow = createDiv().addClass('nowrap');
+  tempoRow = createDiv().addClass('control-row');
   tempoRow.child(makeLabel('Tempo:'));
   tempoSlider = createSlider(1, 12, DEFAULT_TEMPO, 1); tempoSlider.addClass('slider');
   const tVal = createSpan('').style('color', '#cfcfcf');


### PR DESCRIPTION
## Summary
- prevent grouped angle labels from intersecting component view circle
- wrap global controls and mode toggle for better mobile layout
- shrink sliders and allow wrapping to keep controls visible on phones

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0935f29b48320842c835a017fe6ac