### PR TITLE
Align frequency control with play button and fix angle labels

### DIFF
--- a/apps/harmonic-mixer/sketch.js
+++ b/apps/harmonic-mixer/sketch.js
@@ -150,17 +150,23 @@ window.draw = function () {
       const h = lineHeight * lines.length;
 
       if (sorted.length > 1) {
-        // Ensure the label's bounding box stays outside the circle.
-        // Use the radius of a bounding circle (covers width & height)
-        // so labels like "[5, 10]" don't intersect the edge.
-        const dist = Math.sqrt(x * x + y * y);
-        const rLabel = Math.sqrt(w * w + h * h) / 2;
-        const minDist = circleR + rLabel + 4;
-        if (dist < minDist) {
-          const extra = minDist - dist;
-          x += Math.cos(th) * extra;
-          y += Math.sin(th) * extra;
-        }
+        const ensureOutsideCircle = () => {
+          const corners = [
+            [x - w / 2, y - h / 2],
+            [x + w / 2, y - h / 2],
+            [x - w / 2, y + h / 2],
+            [x + w / 2, y + h / 2],
+          ];
+          const minCornerDist = Math.min(...corners.map(([cx, cy]) => Math.hypot(cx, cy)));
+          const minDist = circleR + 4;
+          if (minCornerDist < minDist) {
+            const extra = minDist - minCornerDist;
+            x += Math.cos(th) * extra;
+            y += Math.sin(th) * extra;
+          }
+        };
+
+        ensureOutsideCircle();
 
         // Avoid colliding with the "Angle" label beneath the circle
         const bottomBound = circleR - h / 2 - 8;
@@ -169,6 +175,9 @@ window.draw = function () {
         // Keep list labels within the left half of the canvas
         const rightBound = halfWidth / 2 - w / 2 - 8;
         if (x > rightBound) x = rightBound;
+
+        // Re-check after applying bounds
+        ensureOutsideCircle();
       }
 
       textAlign(CENTER, CENTER);

--- a/apps/harmonic-mixer/ui.js
+++ b/apps/harmonic-mixer/ui.js
@@ -46,7 +46,7 @@ export function buildUI() {
     tabSpiral.removeClass('active');
   });
 
-  // Play group
+  // Play button with f₀ control
   playGroup = createDiv().addClass('group');
   playBtn = createButton('▶'); playBtn.addClass('play-btn'); playBtn.attribute('title', 'Play/Pause');
   playGroup.child(playBtn);
@@ -59,20 +59,20 @@ export function buildUI() {
     refreshPlayButton();
   });
 
-  // Global settings
-  groupGlobal = createDiv().addClass('group');
-
   const f0Row = createDiv().addClass('control-row');
   f0Row.child(makeLabel('f₀ (Hz):'));
   f0Slider = createSlider(80, 160, DEFAULT_F0, 1); f0Slider.addClass('slider');
   const f0Val = createSpan('').style('color', '#cfcfcf');
   f0Row.child(f0Slider); f0Row.child(f0Val);
-  groupGlobal.child(f0Row);
+  playGroup.child(f0Row);
   f0Slider.elt.addEventListener('input', () => {
     setF0(parseInt(f0Slider.value(), 10));
     f0Val.html(' ' + getF0() + ' Hz');
     updateGridUI();
   });
+
+  // Global settings
+  groupGlobal = createDiv().addClass('group');
 
   const masterRow = createDiv().addClass('control-row');
   masterRow.child(makeLabel('Master:'));


### PR DESCRIPTION
## Summary
- Align the f₀ slider and label on the same line as the play button when space permits
- Rework angle label collision logic to keep grouped labels like `[5,10]` outside the circle

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0958fff1483209808b60ebd486bf5