### PR TITLE
Initialize first three partials and add angle arrowheads

### DIFF
--- a/apps/harmonic-mixer/audio.js
+++ b/apps/harmonic-mixer/audio.js
@@ -22,7 +22,10 @@ export const DEFAULT_TEMPO = 4;    // steps/sec (sequence)
 
 // ---------- State ----------
 let f0 = DEFAULT_F0;
-export let gains = Array(PARTIALS).fill(0); gains[0] = 1 * PARTIAL_MAX;
+export let gains = Array(PARTIALS).fill(0);
+gains[0] = 1 * PARTIAL_MAX;
+gains[1] = 0.5 * PARTIAL_MAX;
+gains[2] = 0.25 * PARTIAL_MAX;
 let masterUI = DEFAULT_MASTER;
 let mode = 'mix'; // 'mix' | 'seq'
 let playing = false;
@@ -32,7 +35,10 @@ let seqNextTime = 0;
 
 const auditioning = Array(PARTIALS).fill(false);
 const replacing   = Array(PARTIALS).fill(false);
-const uiValues    = Array(PARTIALS).fill(0); uiValues[0] = 1;
+const uiValues    = Array(PARTIALS).fill(0);
+uiValues[0] = 1;
+uiValues[1] = 0.5;
+uiValues[2] = 0.25;
 
 // Audio graph
 let ctx = null;

--- a/apps/harmonic-mixer/sketch.js
+++ b/apps/harmonic-mixer/sketch.js
@@ -91,14 +91,21 @@ window.draw = function () {
 
       const px = circleR * Math.cos(th);
       const py = circleR * Math.sin(th);
+      const head = terminalCircleSize(k);
+      const lineX = px - Math.cos(th) * head;
+      const lineY = py - Math.sin(th) * head;
 
       stroke(rCol, gCol, bCol, alpha * 255);
       strokeWeight(partialStrokeWeight(k));
-      line(0, 0, px, py);
+      line(0, 0, lineX, lineY);
 
       noStroke();
       fill(rCol, gCol, bCol, alpha * 255);
-      circle(px, py, terminalCircleSize(k));
+      push();
+      translate(px, py);
+      rotate(th);
+      triangle(0, 0, -head, head * 0.6, -head, -head * 0.6);
+      pop();
 
       if (g > 0) {
         let odd = k;


### PR DESCRIPTION
## Summary
- Set initial gains so partials 1–3 default to full, half, and quarter amplitude
- Draw arrowheads instead of dots in the Angle view, scaled for each partial

## Testing
- `node --check apps/harmonic-mixer/audio.js`
- `node --check apps/harmonic-mixer/sketch.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b14000f9808320917972399df021ae