### PR TITLE
feat: add shared playBeep helper

### DIFF
--- a/apps/spiral-trace/audio.js
+++ b/apps/spiral-trace/audio.js
@@ -1,3 +1,5 @@
+import { ensureAudio as ensureCoreAudio, makeMaster, playBeep as corePlayBeep } from '../../lib/audioCore.js';
+
 export const audioState = {
   audioCtx: null,
   masterGain: null,
@@ -7,42 +9,18 @@ export const audioState = {
 };
 
 export function ensureAudio() {
-  const a = audioState;
-  if (!a.audioCtx) {
-    a.audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-    a.masterGain = a.audioCtx.createGain();
-    a.masterGain.gain.value = a.volumePct / 100;
-    a.masterGain.connect(a.audioCtx.destination);
-  } else if (a.audioCtx.state === 'suspended') {
-    a.audioCtx.resume();
+  const ctx = ensureCoreAudio();
+  audioState.audioCtx = ctx;
+  if (!audioState.masterGain) {
+    audioState.masterGain = makeMaster(audioState.volumePct / 100);
+  } else {
+    audioState.masterGain.gain.value = audioState.volumePct / 100;
   }
 }
 
-export function playBeep(fHz, tNow = null) {
-  const { audioCtx, masterGain } = audioState;
-  if (!audioCtx) return;
-  const now = tNow ?? audioCtx.currentTime;
-  const osc = audioCtx.createOscillator();
-  const gain = audioCtx.createGain();
-
-  osc.type = 'sine';
-  osc.frequency.setValueAtTime(fHz, now);
-
-  // Percussive envelope, duration 0.18s (1.5× from earlier 0.12s)
-  const dur = 0.18;
-  const a = 0.006, d = 0.14;
-  const peak = 0.9, sustain = 0.0;
-
-  gain.gain.cancelScheduledValues(now);
-  gain.gain.setValueAtTime(0, now);
-  gain.gain.linearRampToValueAtTime(peak, now + a);
-  gain.gain.linearRampToValueAtTime(sustain, now + a + d);
-
-  osc.connect(gain);
-  gain.connect(masterGain);
-
-  osc.start(now);
-  osc.stop(now + dur + 0.02);
+export function playBeep(fHz, durationMs) {
+  if (!audioState.masterGain) ensureAudio();
+  corePlayBeep(fHz, durationMs, audioState.masterGain);
 }
 
 export function resetAudioProgress() {

--- a/lib/audioCore.js
+++ b/lib/audioCore.js
@@ -21,3 +21,25 @@ export function makeMaster(initialGain = 0.6) {
   return g;
 }
 
+export function playBeep(fHz, durationMs = 180, destination = ensureAudio().destination) {
+  const c = ensureAudio();
+  const now = c.currentTime;
+  const osc = c.createOscillator();
+  const gain = c.createGain();
+
+  osc.type = 'sine';
+  osc.frequency.setValueAtTime(fHz, now);
+
+  const attack = 0.006;
+  const decay = Math.max(0, durationMs / 1000 - attack);
+  gain.gain.setValueAtTime(0, now);
+  gain.gain.linearRampToValueAtTime(0.9, now + attack);
+  gain.gain.linearRampToValueAtTime(0.0, now + attack + decay);
+
+  osc.connect(gain);
+  gain.connect(destination);
+
+  osc.start(now);
+  osc.stop(now + attack + decay + 0.02);
+}
+


### PR DESCRIPTION
## Summary
- add reusable playBeep helper to audio core
- refactor spiral-trace audio module to use shared helpers

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b14d4c6a4c832099e07b7d004afb33