### PR TITLE
refactor: centralize max audible frequency constant

### DIFF
--- a/apps/spiral-trace/audio.js
+++ b/apps/spiral-trace/audio.js
@@ -1,5 +1,7 @@
 import { ensureAudio as ensureCoreAudio, makeMaster, playBeep as corePlayBeep } from '../../lib/audioCore.js';
 
+export const MAX_AUDIBLE_FREQ = 20000;
+
 export const audioState = {
   audioCtx: null,
   masterGain: null,

--- a/apps/spiral-trace/drawing.js
+++ b/apps/spiral-trace/drawing.js
@@ -1,7 +1,7 @@
 import { getSafeArea } from '../../lib/panelFit.js';
 import { TAU, thetaForMultiple } from '../../lib/spiralMath.js';
 import { state, margin, MARKER_CAP } from './state.js';
-import { audioState } from './audio.js';
+import { audioState, MAX_AUDIBLE_FREQ } from './audio.js';
 
 export function getArea(ui) {
   const canvasEl = document.querySelector('canvas');
@@ -46,7 +46,7 @@ export function computeMarkers(finalMultipleK, maxTheta) {
   const K = Math.min(finalMultipleK, MARKER_CAP);
   const arr = [];
   for (let k = 1; k <= K; k++) {
-    if (audioState.baseP * k > 20000) break;
+    if (audioState.baseP * k > MAX_AUDIBLE_FREQ) break;
     const th = thetaForMultiple(k);
     if (th > maxTheta + 1e-9) break;
     arr.push({ k, theta: th });

--- a/apps/spiral-trace/sketch.js
+++ b/apps/spiral-trace/sketch.js
@@ -2,7 +2,7 @@
 import { TAU, thetaForMultiple, radiusAt } from '../../lib/spiralMath.js';
 import { fitScale } from '../../lib/panelFit.js';
 import { state, getFinalAndMax, setX, resetSketch, restartAndPlay, MIN_SPEED, MAX_SPEED, margin } from './state.js';
-import { ensureAudio, playBeep, audioState } from './audio.js';
+import { ensureAudio, playBeep, audioState, MAX_AUDIBLE_FREQ } from './audio.js';
 import { ui, buildUI, refreshPlayPauseLabel, refreshVisualUI, refreshFilterUI, refreshRevealUI, refreshSpeedUI, refreshPitchUI, refreshVolumeUI, syncSpeedSlider } from './ui.js';
 import { getArea, drawGuide, computeMarkers, drawMarkers } from './drawing.js';
 
@@ -48,7 +48,7 @@ window.draw = function () {
 
     while (true) {
       const k = audioState.nextKToFire;
-      if (audioState.baseP * k > 20000) {
+      if (audioState.baseP * k > MAX_AUDIBLE_FREQ) {
         state.finished = true;
         state.paused = true;
         refreshPlayPauseLabel();
@@ -86,7 +86,7 @@ window.draw = function () {
   stroke(255, 160, 120); strokeWeight(3); line(0, 0, B.x, B.y);
 
   const allMarkers = computeMarkers(finalMultipleK, maxTheta);
-  const multiples = allMarkers.filter(m => (m.k % state.kFilter) === 0 && audioState.baseP * m.k <= 20000);
+  const multiples = allMarkers.filter(m => (m.k % state.kFilter) === 0 && audioState.baseP * m.k <= MAX_AUDIBLE_FREQ);
   const visible = (state.revealMode === 'progressive')
     ? multiples.filter(m => m.theta <= state.theta + 1e-9)
     : multiples;
@@ -102,8 +102,8 @@ window.draw = function () {
   const status = state.finished ? 'complete' : (state.paused ? 'paused' : 'running');
   const rDraw = (r_unscaled * s).toFixed(1);
   const finalDraw = (finalR_unscaled * s).toFixed(1);
-  const kMaxDueToAudio = Math.floor(20000 / audioState.baseP);
-  const maxFreqShown = Math.min(20000, audioState.baseP * (kMaxDueToAudio || 1));
+  const kMaxDueToAudio = Math.floor(MAX_AUDIBLE_FREQ / audioState.baseP);
+  const maxFreqShown = Math.min(MAX_AUDIBLE_FREQ, audioState.baseP * (kMaxDueToAudio || 1));
   text(
     `N=${state.rotations_N}  x=${state.x}px  r=${rDraw}px  final=${finalDraw}px  s=${s.toFixed(3)}  k=${state.kFilter}  ` +
     `reveal=${state.revealMode}  speed=${state.dTheta.toFixed(3)}  p=${audioState.baseP}Hz  vol=${audioState.volumePct}%  stop≤${maxFreqShown}Hz  status=${status}`,

--- a/apps/spiral-trace/state.js
+++ b/apps/spiral-trace/state.js
@@ -1,5 +1,5 @@
 import { TAU, radiusAt } from '../../lib/spiralMath.js';
-import { resetAudioProgress } from './audio.js';
+import { resetAudioProgress, MAX_AUDIBLE_FREQ } from './audio.js';
 
 export const state = {
   x: 120,                  // base length (px) for fundamental radius
@@ -14,7 +14,7 @@ export const state = {
 };
 
 export const margin = 32;
-export const MARKER_CAP = 20000;
+export const MARKER_CAP = MAX_AUDIBLE_FREQ;
 export const FILTER_LIST_MAX = 500;
 
 export const MIN_SPEED = 0.002;

--- a/apps/spiral-trace/ui.js
+++ b/apps/spiral-trace/ui.js
@@ -1,5 +1,5 @@
 import { state, setRotations, restartAndPlay, getFinalAndMax, sliderToSpeed, speedToSlider, FILTER_LIST_MAX } from './state.js';
-import { ensureAudio, audioState, resetAudioProgress } from './audio.js';
+import { ensureAudio, audioState, resetAudioProgress, MAX_AUDIBLE_FREQ } from './audio.js';
 
 export let ui;
 export let groupVisual, groupAudio, groupPlay;
@@ -102,7 +102,7 @@ export function buildUI() {
     ensureAudio();
     audioState.baseP = parseInt(pSlider.value(), 10);
     updatePitchLabel();
-    if (audioState.baseP * audioState.nextKToFire > 20000) { state.finished = true; state.paused = true; refreshPlayPauseLabel(); }
+    if (audioState.baseP * audioState.nextKToFire > MAX_AUDIBLE_FREQ) { state.finished = true; state.paused = true; refreshPlayPauseLabel(); }
   });
 
   volSlider.elt.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- export `MAX_AUDIBLE_FREQ` constant in `audio.js`
- replace literal `20000` with `MAX_AUDIBLE_FREQ` across spiral-trace modules
- wire modules to import and use the shared frequency ceiling

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b14f54abc88320b66b6f316e1cc6de