### PR TITLE
refactor: use Math.log2 directly

### DIFF
--- a/lib/spiralMath.js
+++ b/lib/spiralMath.js
@@ -1,9 +1,8 @@
 // ES module: log-spiral helpers
 export const TAU = Math.PI * 2;
-export const log2 = (x) => Math.log(x) / Math.log(2);
 
 // r(θ) = x * 2^(θ / 2π)
 export const radiusAt = (xBase, theta) => xBase * Math.pow(2, theta / TAU);
 
 // For integer multiple k: θ_k = 2π log2(k)
-export const thetaForMultiple = (k) => TAU * log2(k);
+export const thetaForMultiple = (k) => TAU * Math.log2(k);


### PR DESCRIPTION
## Summary
- remove custom log2 helper in `spiralMath`
- compute `thetaForMultiple` using built-in `Math.log2`

## Testing
- `node -e "import('./lib/spiralMath.js').then(m=>console.log('theta', m.thetaForMultiple(8)))"`


------
https://chatgpt.com/codex/tasks/task_e_68b157a50ea88320961b1b00fab9bf1f