### PR TITLE
feat: improve pitch spiral interaction and playback

### DIFF
--- a/apps/pitch-spiral/app.js
+++ b/apps/pitch-spiral/app.js
@@ -1,185 +1,319 @@
+import { ensureAudio, ramp } from '../../lib/audioCore.js';
+
+const TAU = Math.PI * 2;
+const CENTS_TO_ANGLE = TAU / 1200;
+
 const canvas = document.getElementById('spiral');
 const ctx = canvas.getContext('2d');
 const controls = document.getElementById('pitchList');
 const playBtn = document.getElementById('play');
 const addBtn = document.getElementById('add');
+const modeToggle = document.getElementById('modeToggle');
 
 let width, height, cx, cy, outerR, innerR;
 const handleR = 8;
 
+let tonicHz = 110;
+let playMode = 'mix'; // 'mix' | 'seq'
+let playing = false;
+
 const pitches = [
-  {id:0, angle:0, detune:0, fixed:true}
+  { id: 0, baseAngle: 0, detune: 0, fixed: true }
 ];
 let nextId = 1;
 let dragging = null;
+let activePitch = null; // pitch being auditioned via click/drag
+let currentOscs = [];   // oscillators for play button
 
-function resize(){
+function angleFor(p) { return p.baseAngle + p.detune * CENTS_TO_ANGLE; }
+function radiusFor(angle) { return innerR * Math.pow(2, angle / TAU); }
+function colorFor(angle) {
+  const hue = angle / TAU * 360;
+  return `hsl(${hue},100%,50%)`;
+}
+function frequencyFor(p) { return tonicHz * Math.pow(2, angleFor(p) / TAU); }
+
+function resize() {
   canvas.width = window.innerWidth;
   canvas.height = window.innerHeight * 0.75;
   width = canvas.width;
   height = canvas.height;
-  cx = width/2;
-  cy = height/2;
-  outerR = Math.min(width, height)/2 - 20;
-  innerR = outerR/2;
+  cx = width / 2;
+  cy = height / 2;
+  outerR = Math.min(width, height) / 2 - 20;
+  innerR = outerR / 2;
   draw();
 }
 
-function radiusFor(angle){
-  return innerR * Math.pow(2, angle/(2*Math.PI));
-}
-
-function colorFor(angle){
-  const hue = angle/(2*Math.PI)*360;
-  return `hsl(${hue},100%,50%)`;
-}
-
-function draw(){
-  ctx.clearRect(0,0,width,height);
+function draw() {
+  ctx.clearRect(0, 0, width, height);
   ctx.save();
-  ctx.translate(cx,cy);
+  ctx.translate(cx, cy);
   ctx.strokeStyle = '#555';
   ctx.lineWidth = 2;
   ctx.beginPath();
-  ctx.arc(0,0,outerR,0,Math.PI*2);
+  ctx.arc(0, 0, outerR, 0, TAU);
   ctx.stroke();
 
   ctx.beginPath();
-  for(let a=0;a<=Math.PI*2+0.01;a+=0.01){
+  for (let a = 0; a <= TAU + 0.01; a += 0.01) {
     const r = radiusFor(a);
-    const x = r*Math.cos(a);
-    const y = r*Math.sin(a);
-    if(a===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
+    const x = r * Math.cos(a);
+    const y = r * Math.sin(a);
+    if (a === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   }
   ctx.strokeStyle = '#777';
+  ctx.setLineDash([5,5]);
   ctx.stroke();
+  ctx.setLineDash([]);
 
-  pitches.forEach(p=>{
-    const r = radiusFor(p.angle);
-    const x = r*Math.cos(p.angle);
-    const y = r*Math.sin(p.angle);
-    ctx.strokeStyle = colorFor(p.angle);
+  pitches.forEach(p => {
+    const ang = angleFor(p);
+    const r = radiusFor(ang);
+    const x = r * Math.cos(ang);
+    const y = r * Math.sin(ang);
+    ctx.strokeStyle = colorFor(ang);
     ctx.lineWidth = 3;
     ctx.beginPath();
-    ctx.moveTo(0,0);
-    ctx.lineTo(x,y);
+    ctx.moveTo(0, 0);
+    ctx.lineTo(x, y);
     ctx.stroke();
     ctx.fillStyle = ctx.strokeStyle;
     ctx.beginPath();
-    ctx.arc(x,y,handleR,0,Math.PI*2);
+    ctx.arc(x, y, handleR, 0, TAU);
     ctx.fill();
   });
   ctx.restore();
 }
 
-function updateControls(){
-  const sorted = [...pitches].sort((a,b)=>a.angle-b.angle);
+function updateControls() {
+  const sorted = [...pitches].sort((a,b) => angleFor(a) - angleFor(b));
   controls.innerHTML = '';
-  sorted.forEach(p=>{
+  sorted.forEach((p,i) => {
     const row = document.createElement('div');
     row.className = 'pitch-control';
+    const label = document.createElement('span');
+    label.innerHTML = `f<sub>${i*2}</sub>`;
     const slider = document.createElement('input');
-    slider.type='range';
-    slider.min=-100; slider.max=100; slider.value=p.detune;
-    slider.addEventListener('input',e=>{p.detune=parseInt(e.target.value,10);});
+    slider.type = 'range';
+    const color = colorFor(angleFor(p));
+    slider.style.setProperty('accent-color', color);
+    if (p.fixed) {
+      slider.min = 80;
+      slider.max = 160;
+      slider.value = tonicHz;
+      slider.addEventListener('input', e => {
+        tonicHz = parseFloat(e.target.value);
+      });
+    } else {
+      slider.min = -100; slider.max = 100; slider.value = p.detune;
+      slider.addEventListener('input', e => {
+        p.detune = parseInt(e.target.value,10);
+        if (activePitch === p) updatePitchSound(p);
+        draw();
+      });
+    }
     const rm = document.createElement('button');
-    rm.textContent='-';
+    rm.textContent = '-';
     rm.disabled = p.fixed;
-    rm.addEventListener('click',()=>removePitch(p.id));
+    rm.addEventListener('click', () => removePitch(p.id));
+    label.style.color = color;
+    row.appendChild(label);
     row.appendChild(slider);
     row.appendChild(rm);
     controls.appendChild(row);
   });
 }
 
-function removePitch(id){
-  const idx = pitches.findIndex(p=>p.id===id);
-  if(idx>0){
+function removePitch(id) {
+  const idx = pitches.findIndex(p => p.id === id);
+  if (idx > 0) {
     pitches.splice(idx,1);
     updateControls();
     draw();
   }
 }
 
-function addPitch(){
-  const sorted = [...pitches].sort((a,b)=>a.angle-b.angle);
+function addPitch() {
+  const sorted = [...pitches].sort((a,b) => angleFor(a) - angleFor(b));
   let maxGap=-1, startAngle=0, endAngle=0;
-  for(let i=0;i<sorted.length;i++){
-    const a1 = sorted[i].angle;
-    const a2 = (i===sorted.length-1? sorted[0].angle+Math.PI*2 : sorted[i+1].angle);
+  for (let i=0;i<sorted.length;i++) {
+    const a1 = angleFor(sorted[i]);
+    const a2 = (i === sorted.length-1 ? angleFor(sorted[0])+TAU : angleFor(sorted[i+1]));
     const gap = a2 - a1;
-    if(gap>maxGap){maxGap=gap;startAngle=a1;endAngle=a2;}
+    if (gap > maxGap) { maxGap = gap; startAngle=a1; endAngle=a2; }
   }
-  let newAngle = (startAngle+endAngle)/2;
-  if(newAngle>=Math.PI*2) newAngle-=Math.PI*2;
-  pitches.push({id:nextId++, angle:newAngle, detune:0});
+  let newAngle = (startAngle + endAngle) / 2;
+  if (newAngle >= TAU) newAngle -= TAU;
+  pitches.push({ id: nextId++, baseAngle: newAngle, detune:0 });
   updateControls();
   draw();
 }
 
-function playAll(){
-  const audioCtx = new (window.AudioContext||window.webkitAudioContext)();
-  const duration = 1;
-  pitches.forEach(p=>{
-    const osc = audioCtx.createOscillator();
-    const gain = audioCtx.createGain();
-    const freq = 440 * Math.pow(2, p.angle/(2*Math.PI)) * Math.pow(2, p.detune/1200);
-    osc.frequency.value = freq;
-    osc.connect(gain).connect(audioCtx.destination);
-    gain.gain.setValueAtTime(0.3, audioCtx.currentTime);
-    gain.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime+duration);
-    osc.start();
-    osc.stop(audioCtx.currentTime+duration);
-  });
+function startPitchSound(p) {
+  const ctx = ensureAudio();
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = 'sine';
+  osc.frequency.setValueAtTime(frequencyFor(p), ctx.currentTime);
+  gain.gain.setValueAtTime(0, ctx.currentTime);
+  ramp(gain.gain, 0.3, ctx.currentTime);
+  osc.connect(gain).connect(ctx.destination);
+  osc.start();
+  p._osc = osc; p._gain = gain;
+}
+function updatePitchSound(p) {
+  if (p._osc) p._osc.frequency.setValueAtTime(frequencyFor(p), ensureAudio().currentTime);
+}
+function stopPitchSound(p) {
+  if (!p._osc) return;
+  const ctx = ensureAudio();
+  ramp(p._gain.gain, 0, ctx.currentTime);
+  p._osc.stop(ctx.currentTime + 0.05);
+  p._osc = null; p._gain = null;
 }
 
-canvas.addEventListener('mousedown',e=>{
+canvas.addEventListener('mousedown', e => {
   const rect = canvas.getBoundingClientRect();
   const mx = e.clientX - rect.left - cx;
   const my = e.clientY - rect.top - cy;
-  for(const p of pitches){
-    const r = radiusFor(p.angle);
-    const x = r*Math.cos(p.angle);
-    const y = r*Math.sin(p.angle);
+  for (const p of pitches) {
+    const ang = angleFor(p);
+    const r = radiusFor(ang);
+    const x = r * Math.cos(ang);
+    const y = r * Math.sin(ang);
     const dist = Math.hypot(mx - x, my - y);
-    if(dist < handleR+3 && !p.fixed){
-      dragging = p;
-      break;
+    if (dist < handleR + 3) {
+      activePitch = p;
+      startPitchSound(p);
+      if (!p.fixed) {
+        dragging = p;
+        p.baseAngle = ang;
+        p.detune = 0;
+        updateControls();
+      }
+      return;
+    }
+    const t = (mx*x + my*y) / (r*r);
+    if (t > 0 && t < 1) {
+      const lx = x * t;
+      const ly = y * t;
+      const lineDist = Math.hypot(mx - lx, my - ly);
+      if (lineDist < handleR) {
+        activePitch = p;
+        startPitchSound(p);
+        return;
+      }
     }
   }
 });
 
-canvas.addEventListener('mousemove',e=>{
-  if(!dragging) return;
+canvas.addEventListener('mousemove', e => {
+  if (!dragging) return;
   const rect = canvas.getBoundingClientRect();
   let ang = Math.atan2(e.clientY - rect.top - cy, e.clientX - rect.left - cx);
-  if(ang<0) ang += Math.PI*2;
-  ang = Math.min(Math.PI*2, Math.max(0, ang));
-  dragging.angle = ang;
+  if (ang < 0) ang += TAU;
+  ang = Math.min(TAU, Math.max(0, ang));
+  dragging.baseAngle = ang;
   draw();
+  updatePitchSound(dragging);
 });
 
-function finalizeDrag(){
-  if(!dragging) return;
-  const p = dragging;
-  dragging = null;
-  for(const other of pitches){
-    if(other===p) continue;
-    if(Math.abs(other.angle - p.angle) < 0.01){
-      p.angle = Math.max(0, other.angle - 0.01);
+function finalizeDrag() {
+  if (dragging) {
+    const p = dragging;
+    dragging = null;
+    const ang = angleFor(p);
+    for (const other of pitches) {
+      if (other === p) continue;
+      if (Math.abs(angleFor(other) - ang) < 0.01) {
+        p.baseAngle = Math.max(0, angleFor(other) - 0.01);
+      }
     }
+    updateControls();
+    draw();
   }
-  updateControls();
-  draw();
+  if (activePitch) {
+    stopPitchSound(activePitch);
+    activePitch = null;
+  }
 }
 
 canvas.addEventListener('mouseup', finalizeDrag);
 canvas.addEventListener('mouseleave', finalizeDrag);
 
+function stopPlayback() {
+  currentOscs.forEach(({osc,gain}) => {
+    const ctx = ensureAudio();
+    ramp(gain.gain, 0, ctx.currentTime);
+    osc.stop(ctx.currentTime + 0.05);
+  });
+  currentOscs = [];
+  playing = false;
+  playBtn.textContent = '▶';
+}
+
+async function startSequential() {
+  const ctx = ensureAudio();
+  const sorted = [...pitches].sort((a,b)=>angleFor(a) - angleFor(b));
+  const dur = 500; // ms per note
+  for (const p of sorted) {
+    if (!playing) break;
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type='sine';
+    osc.frequency.setValueAtTime(frequencyFor(p), ctx.currentTime);
+    gain.gain.setValueAtTime(0, ctx.currentTime);
+    osc.connect(gain).connect(ctx.destination);
+    osc.start();
+    ramp(gain.gain,0.3,ctx.currentTime);
+    ramp(gain.gain,0,ctx.currentTime + (dur-50)/1000);
+    osc.stop(ctx.currentTime + dur/1000);
+    currentOscs=[{osc,gain}];
+    await new Promise(r=>setTimeout(r,dur));
+    currentOscs=[];
+  }
+  stopPlayback();
+}
+
+function startTogether() {
+  const ctx = ensureAudio();
+  const sorted = [...pitches].sort((a,b)=>angleFor(a) - angleFor(b));
+  const dur = 1000;
+  sorted.forEach(p=>{
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type='sine';
+    osc.frequency.setValueAtTime(frequencyFor(p), ctx.currentTime);
+    gain.gain.setValueAtTime(0, ctx.currentTime);
+    osc.connect(gain).connect(ctx.destination);
+    osc.start();
+    ramp(gain.gain,0.3,ctx.currentTime);
+    ramp(gain.gain,0,ctx.currentTime + (dur-50)/1000);
+    osc.stop(ctx.currentTime + dur/1000);
+    currentOscs.push({osc,gain});
+  });
+  setTimeout(()=>{ if(playing) stopPlayback(); }, dur);
+}
+
+playBtn.addEventListener('click', () => {
+  if (playing) {
+    stopPlayback();
+  } else {
+    playing = true;
+    playBtn.textContent = '❚❚';
+    if (playMode === 'seq') startSequential(); else startTogether();
+  }
+});
+
+modeToggle.addEventListener('click', () => {
+  playMode = playMode === 'mix' ? 'seq' : 'mix';
+  modeToggle.classList.toggle('seq', playMode === 'seq');
+});
+
 addBtn.addEventListener('click', addPitch);
-playBtn.addEventListener('click', playAll);
 
 window.addEventListener('resize', resize);
 resize();
 updateControls();
-
+draw();

--- a/apps/pitch-spiral/index.html
+++ b/apps/pitch-spiral/index.html
@@ -9,8 +9,12 @@
     #app{display:flex;flex-direction:column}
     canvas{flex:3;display:block;background:#000}
     #controls{flex:1;background:#222;padding:8px;overflow:auto}
-    #topControls{margin-bottom:8px}
-    #topControls button{margin-right:8px}
+    #topControls{margin-bottom:8px;display:flex;align-items:center;gap:8px}
+    #topControls button{margin-right:0}
+    #modeCtrl{display:flex;align-items:center;gap:4px}
+    .mode-toggle{width:40px;height:20px;border:1px solid #888;border-radius:10px;position:relative;cursor:pointer}
+    .mode-toggle .mode-knob{position:absolute;top:1px;left:1px;width:18px;height:18px;border-radius:50%;background:#888;transition:left 0.2s}
+    .mode-toggle.seq .mode-knob{left:21px}
     #pitchList{display:flex;flex-direction:column;gap:6px}
     .pitch-control{display:flex;align-items:center;gap:8px;border:1px solid #444;padding:4px;border-radius:4px;background:#333}
     .pitch-control input[type=range]{flex:1}
@@ -21,7 +25,12 @@
     <canvas id="spiral"></canvas>
     <div id="controls">
       <div id="topControls">
-        <button id="play">Play</button>
+        <button id="play">▶</button>
+        <div id="modeCtrl">
+          <span>Together</span>
+          <div id="modeToggle" class="mode-toggle"><div class="mode-knob"></div></div>
+          <span>Sequential</span>
+        </div>
         <button id="add">+</button>
       </div>
       <div id="pitchList"></div>


### PR DESCRIPTION
## Summary
- add tonic frequency control and per-pitch fine tuners with color-coded sliders
- enable audition by clicking/dragging pitches and smooth play modes (together or sequential)
- style spiral as dashed and reorganize top controls with play/pause, mode toggle, and add button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b192b3126c8320840de8eacd3381f7