### PR TITLE
Enhance pitch spiral tuner controls and playback

### DIFF
--- a/apps/pitch-spiral/index.html
+++ b/apps/pitch-spiral/index.html
@@ -14,7 +14,7 @@
     #modeCtrl{display:flex;align-items:center;gap:4px}
     .mode-toggle{width:40px;height:20px;border:1px solid #888;border-radius:10px;position:relative;cursor:pointer}
     .mode-toggle .mode-knob{position:absolute;top:1px;left:1px;width:18px;height:18px;border-radius:50%;background:#888;transition:left 0.2s}
-    .mode-toggle.seq .mode-knob{left:21px}
+    .mode-toggle.mix .mode-knob{left:21px}
     #pitchList{display:flex;flex-direction:column;gap:6px}
     .pitch-control{display:flex;align-items:center;gap:8px;border:1px solid #444;padding:4px;border-radius:4px;background:#333}
     .pitch-control input[type=range]{flex:1}
@@ -27,9 +27,9 @@
       <div id="topControls">
         <button id="play">▶</button>
         <div id="modeCtrl">
-          <span>Together</span>
-          <div id="modeToggle" class="mode-toggle"><div class="mode-knob"></div></div>
           <span>Sequential</span>
+          <div id="modeToggle" class="mode-toggle"><div class="mode-knob"></div></div>
+          <span>Together</span>
         </div>
         <button id="add">+</button>
       </div>


### PR DESCRIPTION
## Summary
- Update fine tuner sliders to reflect pitch color in real time and limit range to ±50 cents
- Rework sequential/together toggle with sequential default and stop/play button behaviour
- Smooth oscillator start/stop and loop sequential playback continuously

## Testing
- `node --check apps/pitch-spiral/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b198c8595c8320b18309b1a70d35fc