### PR TITLE
Improve pitch spiral playback and controls

### DIFF
--- a/apps/pitch-spiral/index.html
+++ b/apps/pitch-spiral/index.html
@@ -12,9 +12,10 @@
     #topControls{margin-bottom:8px;display:flex;align-items:center;gap:8px}
     #topControls button{margin-right:0}
     #modeCtrl{display:flex;align-items:center;gap:4px}
+    #topControls input[type=range]{width:100px}
     .mode-toggle{width:40px;height:20px;border:1px solid #888;border-radius:10px;position:relative;cursor:pointer}
     .mode-toggle .mode-knob{position:absolute;top:1px;left:1px;width:18px;height:18px;border-radius:50%;background:#888;transition:left 0.2s}
-    .mode-toggle.mix .mode-knob{left:21px}
+    .mode-toggle.withf0 .mode-knob{left:21px}
     #pitchList{display:flex;flex-direction:column;gap:6px}
     .pitch-control{display:flex;align-items:center;gap:8px;border:1px solid #444;padding:4px;border-radius:4px;background:#333}
     .pitch-control input[type=range]{flex:1}
@@ -27,11 +28,12 @@
       <div id="topControls">
         <button id="play">▶</button>
         <div id="modeCtrl">
-          <span>Sequential</span>
+          <span>Without f0</span>
           <div id="modeToggle" class="mode-toggle"><div class="mode-knob"></div></div>
-          <span>Together</span>
+          <span>With f0</span>
         </div>
         <button id="add">+</button>
+        <input id="volume" type="range" min="0" max="100" value="50" />
       </div>
       <div id="pitchList"></div>
     </div>


### PR DESCRIPTION
## Summary
- add global volume control and replace sequential/together switch with Without f0/With f0 toggle
- play pitches with smooth triangle waves and optional continuous f0
- allow fine-tune sliders to audition notes in real time

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a11c27bc8320981634115dba1747