### PR TITLE
Refine landing page copy and adjust f0 drone behavior

### DIFF
--- a/apps/pitch-spiral/app.js
+++ b/apps/pitch-spiral/app.js
@@ -366,6 +366,7 @@ function stopPlayback() {
   currentOscs = [];
   playing = false;
   playBtn.textContent = '▶';
+  stopF0();
 }
 
 async function startSequential() {
@@ -410,7 +411,7 @@ playBtn.addEventListener('click', () => {
 modeToggle.addEventListener('click', () => {
   playMode = playMode === 'withf0' ? 'nof0' : 'withf0';
   modeToggle.classList.toggle('withf0', playMode === 'withf0');
-  if (playMode === 'withf0') startF0(); else stopF0();
+  if (playing && playMode === 'withf0') startF0(); else stopF0();
 });
 
 addBtn.addEventListener('click', addPitch);
@@ -420,4 +421,4 @@ resize();
 updateControls();
 draw();
 modeToggle.classList.toggle('withf0', playMode === 'withf0');
-if (playMode === 'withf0') startF0();
+

--- a/index.html
+++ b/index.html
@@ -16,16 +16,16 @@
   <main>
     <h1>Log Spiral Tools</h1>
     <div class="card">
-      <h2><a href="apps/spiral-trace/">Spiral Trace (Harmonics Path + Beeps)</a></h2>
-      <p>Your original app: logarithmic spiral tracing with marker sonification.</p>
+      <h2><a href="apps/spiral-trace/">Spiral Trace</a></h2>
+      <p>Explore multi-octave harmonic relationships inside a logarithmic spiral.</p>
     </div>
     <div class="card">
-      <h2><a href="apps/harmonic-mixer/">Harmonic Mixer (16 partials)</a></h2>
-      <p>Mix fundamental + 15 overtones, visualize on a log spiral, audition sliders, and hear together or in sequence.</p>
+      <h2><a href="apps/harmonic-mixer/">Harmonic Mixer</a></h2>
+      <p>Mix harmonics at various levels of loudness to create timbres</p>
     </div>
     <div class="card">
-      <h2><a href="apps/pitch-spiral/">Pitch Spiral (drag & play)</a></h2>
-      <p>Arrange pitch lines on a log spiral, drag to new angles, add or remove pitches, and play them.</p>
+      <h2><a href="apps/pitch-spiral/">Pitch Spiral</a></h2>
+      <p>Explore pitch relationships within a logarithmic single-octave spiral</p>
     </div>
   </main>
 </body>


### PR DESCRIPTION
## Summary
- Simplify home page titles and descriptions for Spiral Trace, Harmonic Mixer, and Pitch Spiral apps.
- Ensure pitch spiral's f0 drone only sounds during active playback and stops when playback ends.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ccfe2c5883208a93085480ba5a11