### PR TITLE
Improve documentation and pitch spiral controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,69 @@
 # Log Spiral Tools
 
-Interactive web sketches that visualize logarithmic spirals and relate them to sound.  The project currently hosts two small p5.js applications that run entirely in the browser and require no build step or dependencies beyond a modern web browser.
+Log Spiral Tools is a collection of tiny, dependency‑free web sketches
+that connect the geometry of the logarithmic spiral with sound.  Each
+application runs entirely in the browser; simply open the HTML file and
+start experimenting.
 
-## Live Demo
-- [Open the published site](https://atrianglehead.github.io/log-spiral/)
+## Try it now
 
-## Applications
-### Spiral Trace
-A spiral visualizer that plots a logarithmic spiral and places markers at integer-multiple radii.  Each marker can trigger a short sine beep using the Web Audio API.
+Visit the [main page](https://atrianglehead.github.io/log-spiral/) to
+launch any of the sketches instantly.
 
-Key features:
-- Adjustable number of rotations and base radius.
-- Optional filtering so only multiples of *k* are shown or heard.
-- Two marker reveal modes: show all from the start or reveal progressively as the spiral grows.
-- Log‑scaled speed slider with on‑screen readout.
-- Base pitch and master volume controls (beeps stop at 20 kHz).
-- Play/pause button plus keyboard shortcuts: `Space` toggles play, `R` resets, `+`/`-` adjust speed, `{`/`}` change base radius, `M` toggles marker mode.
-- Panel‑aware layout keeps the spiral from overlapping the control panel even when the window resizes.
+## Quick start
 
-### Harmonic Mixer
-A 16‑partial harmonic mixing tool.  Each partial is visualized on the spiral and can be adjusted with its own slider.
-
-Highlights:
-- Fundamental plus 15 overtones with individual amplitude sliders.
-- Mix mode: hear all active partials together.
-- Sequence mode: step through partials one by one at a chosen tempo.
-- Audition a single partial while adjusting its slider.
-- Smooth gain transitions to avoid clicks.
-- Slider knobs match each partial's color for quick visual association.
-
-## Getting Started
 1. Clone this repository.
-2. Open `index.html` in your browser or serve the folder with a local web server (e.g. `python -m http.server`).
+2. Open `index.html` in your browser, or serve the folder locally with
+   a simple HTTP server such as `python -m http.server`.
 3. Choose an application from the landing page.
 
-No build process is required.  p5.js and other libraries are loaded from a CDN.  Audio starts only after the first user interaction to comply with browser autoplay policies.
+No build process is required; libraries are loaded from CDNs and audio
+only begins after the first user interaction to satisfy autoplay
+policies.
 
-## Repository Layout
+## Applications
+
+### Pitch Spiral
+Arrange pitches around a spiral and audition them in sequence.
+
+* Toggle an **f₀ drone** for reference with a single button.
+* Add, drag and fine‑tune additional pitches.
+* Master volume control and sequential playback.
+
+### Spiral Trace
+Plot a logarithmic spiral and trigger a short sine beep when the spiral
+passes marked radii.
+
+* Adjustable rotations and base radius.
+* Filter markers to only show multiples of *k*.
+* Base pitch and master volume controls.
+
+### Harmonic Mixer
+Visualise and mix the first sixteen harmonics of a fundamental pitch.
+
+* Individual amplitude sliders for each partial.
+* Mix mode or step‑through sequence mode.
+* Audition a single partial while adjusting its slider.
+
+## Repository layout
+
 ```
-index.html         – landing page linking to each tool
-apps/spiral-trace/ – Spiral Trace application
+index.html           – landing page linking to each tool
+apps/spiral-trace/   – Spiral Trace application
 apps/harmonic-mixer/ – Harmonic Mixer application
-lib/               – shared ES modules (spiral math, panel fitting, audio helpers)
-LICENSE            – project license (GPLv3)
+apps/pitch-spiral/   – Pitch Spiral application
+lib/                 – shared ES modules (spiral math, panel fitting, audio helpers)
+LICENSE              – project license (GPLv3)
 ```
 
 ## Contributing
-Pull requests are welcome.  Please keep the project small and dependency‑free; each application should run by simply opening its `index.html` in a browser.
+
+Pull requests are welcome.  Please keep the project small and
+dependency‑free; each application should run by simply opening its
+`index.html` in a browser.
 
 ## License
-This project is licensed under the [GNU General Public License v3](LICENSE).
+
+This project is licensed under the
+[GNU General Public License v3](LICENSE).
+

--- a/apps/pitch-spiral/app.js
+++ b/apps/pitch-spiral/app.js
@@ -8,7 +8,7 @@ const ctx = canvas.getContext('2d');
 const controls = document.getElementById('pitchList');
 const playBtn = document.getElementById('play');
 const addBtn = document.getElementById('add');
-const f0Slider = document.getElementById('f0vol');
+const f0Btn = document.getElementById('f0drone');
 const volumeSlider = document.getElementById('volume');
 
 let width, height, cx, cy, outerR, innerR;
@@ -20,6 +20,7 @@ const NOTE_GAIN_F0 = 0.2;
 
 let tonicHz = 110;
 let playing = false;
+let f0DroneOn = false;
 
 const master = makeMaster(0.5);
 volumeSlider.addEventListener('input', e => {
@@ -136,7 +137,6 @@ function updateControls() {
       p.muted = !p.muted;
       if (p._osc) stopPitchSound(p);
       updateControls();
-      updateDrone();
     });
     const solo = document.createElement('button');
     solo.textContent = 'S';
@@ -145,7 +145,6 @@ function updateControls() {
       p.solo = !p.solo;
       if (p._osc) stopPitchSound(p);
       updateControls();
-      updateDrone();
     });
     const label = document.createElement('span');
     label.innerHTML = `f<sub>${i}</sub>`;
@@ -217,7 +216,6 @@ function removePitch(id) {
     pitches.splice(idx,1);
     updateControls();
     draw();
-    updateDrone();
   }
 }
 
@@ -294,9 +292,7 @@ function stopPitchSound(p) {
 }
 
 function updateDrone() {
-  const lvl = parseInt(f0Slider.value,10) / 100;
-  const enabled = isPitchEnabled(pitches[0]) && lvl > 0;
-  if (enabled) {
+  if (f0DroneOn) {
     const ctx = ensureAudio();
     if (!f0Osc) {
       f0Osc = ctx.createOscillator();
@@ -307,7 +303,7 @@ function updateDrone() {
       f0Osc.connect(f0Gain).connect(master);
       f0Osc.start();
     }
-    ramp(f0Gain.gain, NOTE_GAIN_F0 * lvl, ctx.currentTime, FADE_MS);
+    ramp(f0Gain.gain, NOTE_GAIN_F0, ctx.currentTime, FADE_MS);
   } else if (f0Osc) {
     const ctx = ensureAudio();
     ramp(f0Gain.gain, 0, ctx.currentTime, FADE_MS);
@@ -438,7 +434,12 @@ playBtn.addEventListener('click', () => {
   }
 });
 
-f0Slider.addEventListener('input', updateDrone);
+f0Btn.addEventListener('click', () => {
+  f0DroneOn = !f0DroneOn;
+  f0Btn.classList.toggle('active', f0DroneOn);
+  f0Btn.innerHTML = `f<sub>0</sub> Drone ${f0DroneOn ? '🔊' : '🔇'}`;
+  updateDrone();
+});
 
 addBtn.addEventListener('click', addPitch);
 

--- a/apps/pitch-spiral/index.html
+++ b/apps/pitch-spiral/index.html
@@ -11,6 +11,7 @@
     #controls{flex:1;background:#222;padding:8px;overflow:auto}
     #topControls{margin-bottom:8px;display:flex;align-items:center;gap:8px}
     #topControls button{margin-right:0}
+    #topControls button.active{background:#555}
     #topControls input[type=range]{width:100px}
     #addSection{margin-bottom:8px;display:flex;align-items:center;gap:8px}
     #pitchList{display:flex;flex-direction:column;gap:6px}
@@ -25,8 +26,8 @@
     <div id="controls">
       <div id="topControls">
         <button id="play">▶</button>
-        <span>f<sub>0</sub> drone</span>
-        <input id="f0vol" type="range" min="0" max="100" value="0" />
+        <button id="f0drone">f<sub>0</sub> Drone 🔇</button>
+        <span>🔊</span>
         <input id="volume" type="range" min="0" max="100" value="50" />
       </div>
       <div id="addSection">


### PR DESCRIPTION
## Summary
- Rewrite README with clearer quick start instructions and main page link
- Add f₀ drone toggle button and master volume icon to Pitch Spiral UI
- Ensure drone playback is independent from individual pitch mute/solo controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1da9a19b483208165b08eda9e1e1e