### PR TITLE
Fix click when releasing pitch controls

### DIFF
--- a/lib/audioCore.js
+++ b/lib/audioCore.js
@@ -9,7 +9,12 @@ export const audioNow = () => (ctx ? ctx.currentTime : 0);
 
 // 20 ms linear ramps by default
 export function ramp(param, value, when = audioNow(), ms = 20) {
-  param.cancelScheduledValues(when);
+  if (typeof param.cancelAndHoldAtTime === 'function') {
+    param.cancelAndHoldAtTime(when);
+  } else {
+    param.cancelScheduledValues(when);
+    param.setValueAtTime(param.value, when);
+  }
   param.linearRampToValueAtTime(value, when + ms / 1000);
 }
 


### PR DESCRIPTION
## Summary
- preserve current Web Audio parameter values before scheduling new ramps to avoid discontinuities

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b473dea6088320b78c203dc1160758