### PR TITLE
Make pitch-spiral audio attack crisp

### DIFF
--- a/apps/pitch-spiral/app.js
+++ b/apps/pitch-spiral/app.js
@@ -17,8 +17,8 @@ const volumeSlider = document.getElementById('volume');
 
 let width, height, cx, cy, outerR, innerR;
 const handleR = 8;
-// longer fade times for smoother starts/stops
-const FADE_MS = 500;
+// short fade for crisp, plucked sound
+const FADE_MS = 20;
 const NOTE_GAIN = 0.3;
 const NOTE_GAIN_F0 = 0.2;
 


### PR DESCRIPTION
## Summary
- Shorten fade time in Pitch Spiral for plucked, immediate note attacks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4781e1ea083208892430842fc617c