### PR TITLE
Fix pitch-spiral fine tuner sliders stuck

### DIFF
--- a/apps/pitch-spiral/app.js
+++ b/apps/pitch-spiral/app.js
@@ -192,10 +192,9 @@ function updateControls() {
         if (p._osc) updatePitchSound(p);
       };
       slider.addEventListener('input', handleInput);
-      const start = e => { e.preventDefault(); activePitch = p; startPitchSound(p); };
-      const end = e => {
-        if (e) e.preventDefault();
-        if (activePitch===p) { stopPitchSound(p); activePitch=null; }
+      const start = () => { activePitch = p; startPitchSound(p); };
+      const end = () => {
+        if (activePitch === p) { stopPitchSound(p); activePitch = null; }
         if (needsUpdate) { updateControls(); needsUpdate = false; }
       };
       slider.addEventListener('pointerdown', start);


### PR DESCRIPTION
## Summary
- Allow fine tuner range inputs to move by removing `preventDefault` from pointer handlers

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b47c5a8e308320ab08a5ce1c175a88