### PR TITLE
Handle double click via click event and set canvas beige

### DIFF
--- a/apps/circle-score/app.js
+++ b/apps/circle-score/app.js
@@ -103,7 +103,8 @@ document.addEventListener('keydown', e => {
   }
 });
 
-canvas.addEventListener('dblclick', e => {
+canvas.addEventListener('click', e => {
+  if (e.detail !== 2) return;
   const rect = canvas.getBoundingClientRect();
   const x = e.clientX - rect.left;
   const y = e.clientY - rect.top;

--- a/apps/circle-score/index.html
+++ b/apps/circle-score/index.html
@@ -7,7 +7,7 @@
   <style>
     html,body,#app{height:100%;margin:0;background:#111;color:#eee;font:16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif}
     #app{display:flex;flex-direction:column}
-    canvas{flex:1;display:block;background:#000}
+    canvas{flex:1;display:block;background:beige}
     #controls{background:#222;padding:8px;display:flex;align-items:center;gap:8px}
     #controls label{display:flex;align-items:center;gap:4px}
     input[type=number]{width:40px}


### PR DESCRIPTION
## Summary
- ensure circle score canvas uses beige background
- detect double-clicks via click event detail for broader compatibility

## Testing
- `node --check apps/circle-score/app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c277885dc08320b1085acf13f9f09d