### PR TITLE
Improve circle-score contrast and playback

### DIFF
--- a/apps/circle-score/index.html
+++ b/apps/circle-score/index.html
@@ -17,6 +17,7 @@
   <div id="app">
     <canvas id="score"></canvas>
     <div id="controls">
+      <button id="play">▶</button>
       <label>Beats: <input id="beatCount" type="number" min="0" max="9" value="4"></label>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Draw circles and beats in black for better contrast on the beige canvas
- Add play/pause control to sequentially play each circle's phrase

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68c2804092c4832092c5c6ca51776801