### PR TITLE
Ensure circle score selects circle or line exclusively

### DIFF
--- a/apps/circle-score/app.js
+++ b/apps/circle-score/app.js
@@ -160,11 +160,12 @@ canvas.addEventListener('mousedown', e => {
     const dy = y - c.y;
     const dist = Math.hypot(dx, dy);
     if (dist <= c.r) {
-      selectedCircle = c;
-      selectedLine = null;
       // audition if near center
       if (dist < 10) {
+        selectedCircle = c;
+        selectedLine = null;
         startAudition(c);
+        draw();
         return;
       }
       const ang = (Math.atan2(dx, -dy) + TAU) % TAU;
@@ -172,10 +173,14 @@ canvas.addEventListener('mousedown', e => {
         const diff = Math.abs(((c.lines[i] - ang + TAU + TAU / 2) % TAU) - TAU / 2);
         if (diff < 0.1) {
           selectedLine = { circle: c, index: i };
+          selectedCircle = null;
           draggingLine = selectedLine;
-          break;
+          draw();
+          return;
         }
       }
+      selectedCircle = c;
+      selectedLine = null;
       draw();
       return;
     }


### PR DESCRIPTION
## Summary
- ensure circle score only highlights the most recently selected shape

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c282afe9dc8320aec0454976db4866