### PR TITLE
Remove gap between circles in circle score

### DIFF
--- a/apps/circle-score/app.js
+++ b/apps/circle-score/app.js
@@ -282,7 +282,9 @@ function startSegment() {
     if (playCircleIdx >= circles.length) {
       stopPlayback();
     } else {
-      playTimer = setTimeout(() => startCircle(circles[playCircleIdx]), 250);
+      // start next circle immediately with no gap
+      playTimer = null;
+      startCircle(circles[playCircleIdx]);
     }
     return;
   }


### PR DESCRIPTION
## Summary
- eliminate artificial 250ms pause between circles in circle-score playback so rhythm is continuous

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c287769a9c8320b7a17f50a82c7917