### PR TITLE
Enable touch support for Circle Score

### DIFF
--- a/apps/circle-score/index.html
+++ b/apps/circle-score/index.html
@@ -19,6 +19,7 @@
     <div id="controls">
       <button id="play">▶</button>
       <label>Beats: <input id="beatCount" type="number" min="0" max="9" value="4"></label>
+      <button id="delete">Delete</button>
     </div>
   </div>
   <script type="module" src="app.js"></script>


### PR DESCRIPTION
## Summary
- add Delete button to Circle Score controls
- switch to pointer events with double-tap detection for mobile interactions

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c28b0b5354832084bb9287170cb4c5