### PR TITLE
Fix mobile audio and double tap in circle score

### DIFF
--- a/apps/circle-score/app.js
+++ b/apps/circle-score/app.js
@@ -180,15 +180,18 @@ canvas.addEventListener('pointerdown', e => {
   const rect = canvas.getBoundingClientRect();
   const x = e.clientX - rect.left;
   const y = e.clientY - rect.top;
-  const now = performance.now();
-  if (now - lastTap < 300 && Math.hypot(x - lastTapX, y - lastTapY) < 20) {
-    handleDoubleTap(x, y);
-    lastTap = 0;
-    return;
+  if (e.pointerType === 'touch') {
+    e.preventDefault();
+    const now = performance.now();
+    if (now - lastTap < 300 && Math.hypot(x - lastTapX, y - lastTapY) < 20) {
+      handleDoubleTap(x, y);
+      lastTap = 0;
+      return;
+    }
+    lastTap = now;
+    lastTapX = x;
+    lastTapY = y;
   }
-  lastTap = now;
-  lastTapX = x;
-  lastTapY = y;
   for (const c of circles) {
     const dx = x - c.x;
     const dy = y - c.y;
@@ -221,6 +224,14 @@ canvas.addEventListener('pointerdown', e => {
   selectedCircle = null;
   selectedLine = null;
   draw();
+});
+
+canvas.addEventListener('dblclick', e => {
+  ensureAudio();
+  const rect = canvas.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+  handleDoubleTap(x, y);
 });
 
 canvas.addEventListener('pointermove', e => {

--- a/lib/audioCore.js
+++ b/lib/audioCore.js
@@ -2,7 +2,7 @@
 let ctx = null;
 export function ensureAudio() {
   if (!ctx) ctx = new (window.AudioContext || window.webkitAudioContext)();
-  else if (ctx.state === 'suspended') ctx.resume();
+  if (ctx.state === 'suspended') ctx.resume();
   return ctx;
 }
 export const audioNow = () => (ctx ? ctx.currentTime : 0);


### PR DESCRIPTION
## Summary
- resume Web Audio context whenever ensureAudio is called
- support mobile double-tap and desktop double-click for adding lines or circles

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c28fe4886883209b81f2899f8e089a