### PR TITLE
refactor circle-score drawing

### DIFF
--- a/apps/circle-score/CircleScore.js
+++ b/apps/circle-score/CircleScore.js
@@ -1,4 +1,5 @@
 import { playBeep, ensureAudio } from '../../lib/audioCore.js';
+import { drawCircle, drawPlayhead } from './renderer.js';
 
 const TAU = Math.PI * 2;
 
@@ -98,41 +99,15 @@ export class CircleScore {
   draw() {
     this.ctx.clearRect(0, 0, this.width, this.height);
     this.circles.forEach((c, idx) => {
-      this.ctx.lineWidth = c === this.selectedCircle ? 4 : 2;
-      this.ctx.strokeStyle = '#000';
-      this.ctx.beginPath();
-      this.ctx.arc(c.x, c.y, c.r, 0, TAU);
-      this.ctx.stroke();
-      c.lines.forEach((angle, i) => {
-        const sel =
-          this.selectedLine &&
-          this.selectedLine.circle === c &&
-          this.selectedLine.index === i;
-        this.ctx.lineWidth = sel ? 4 : 2;
-        this.ctx.beginPath();
-        this.ctx.moveTo(c.x, c.y);
-        this.ctx.lineTo(
-          c.x + c.r * Math.sin(angle),
-          c.y - c.r * Math.cos(angle)
-        );
-        this.ctx.stroke();
-      });
+      const selected = c === this.selectedCircle;
+      const selectedLineIndex =
+        this.selectedLine && this.selectedLine.circle === c
+          ? this.selectedLine.index
+          : null;
+      drawCircle(this.ctx, c, { selected, selectedLineIndex });
       if (this.playing && idx === this.playCircleIdx) {
-        this.ctx.strokeStyle = '#f00';
-        this.ctx.lineWidth = 2;
-        this.ctx.beginPath();
-        this.ctx.moveTo(c.x, c.y);
-        this.ctx.lineTo(
-          c.x + c.r * Math.sin(this.playheadAngle),
-          c.y - c.r * Math.cos(this.playheadAngle)
-        );
-        this.ctx.stroke();
+        drawPlayhead(this.ctx, c, this.playheadAngle);
       }
-      // center dot
-      this.ctx.fillStyle = '#000';
-      this.ctx.beginPath();
-      this.ctx.arc(c.x, c.y, 3, 0, TAU);
-      this.ctx.fill();
     });
   }
 

--- a/apps/circle-score/renderer.js
+++ b/apps/circle-score/renderer.js
@@ -1,0 +1,40 @@
+const TAU = Math.PI * 2;
+
+export function drawCircle(ctx, circle, opts = {}) {
+  const { selected = false, selectedLineIndex = null } = opts;
+
+  ctx.lineWidth = selected ? 4 : 2;
+  ctx.strokeStyle = '#000';
+  ctx.beginPath();
+  ctx.arc(circle.x, circle.y, circle.r, 0, TAU);
+  ctx.stroke();
+
+  circle.lines.forEach((angle, i) => {
+    const isSelected = i === selectedLineIndex;
+    ctx.lineWidth = isSelected ? 4 : 2;
+    ctx.beginPath();
+    ctx.moveTo(circle.x, circle.y);
+    ctx.lineTo(
+      circle.x + circle.r * Math.sin(angle),
+      circle.y - circle.r * Math.cos(angle)
+    );
+    ctx.stroke();
+  });
+
+  ctx.fillStyle = '#000';
+  ctx.beginPath();
+  ctx.arc(circle.x, circle.y, 3, 0, TAU);
+  ctx.fill();
+}
+
+export function drawPlayhead(ctx, circle, angle) {
+  ctx.strokeStyle = '#f00';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(circle.x, circle.y);
+  ctx.lineTo(
+    circle.x + circle.r * Math.sin(angle),
+    circle.y - circle.r * Math.cos(angle)
+  );
+  ctx.stroke();
+}


### PR DESCRIPTION
## Summary
- add pure rendering helpers for circle and playhead
- use renderer functions in CircleScore draw method

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c29a2095b48320a6ddb7e88ec09406