### PR TITLE
Maintain ordered lines when dragging in circle score

### DIFF
--- a/apps/circle-score/Circle.js
+++ b/apps/circle-score/Circle.js
@@ -40,6 +40,21 @@ export class Circle {
     this._assertSorted();
   }
 
+  updateLine(index, angle) {
+    // Remove the existing line
+    this.lines.splice(index, 1);
+    // Find new insertion index to keep lines sorted
+    const newIdx = this.lines.findIndex(a => a > angle);
+    if (newIdx === -1) {
+      this.lines.push(angle);
+      this._assertSorted();
+      return this.lines.length - 1;
+    }
+    this.lines.splice(newIdx, 0, angle);
+    this._assertSorted();
+    return newIdx;
+  }
+
   generateSegments(startAngle = 0) {
     this._assertSorted();
     const angles = this.lines;

--- a/apps/circle-score/CircleScore.js
+++ b/apps/circle-score/CircleScore.js
@@ -204,7 +204,8 @@ export class CircleScore {
     const { x, y } = getCanvasPos(this.canvas, e);
     const c = this.draggingLine.circle;
     const angle = (Math.atan2(x - c.x, -(y - c.y)) + TAU) % TAU;
-    c.lines[this.draggingLine.index] = angle;
+    const newIdx = c.updateLine(this.draggingLine.index, angle);
+    this.draggingLine.index = newIdx;
     this.draw();
   }
 


### PR DESCRIPTION
## Summary
- Add `updateLine` to `Circle` to reinsert moved lines while keeping angles sorted
- Use `updateLine` in `CircleScore.onPointerMove` to keep dragging index in sync

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2efb0786883209b68aaee8e0d9124