### PR TITLE
Remove audio unlock from CircleScore interactions

### DIFF
--- a/apps/circle-score/CircleScore.js
+++ b/apps/circle-score/CircleScore.js
@@ -1,4 +1,3 @@
-import { ensureAudio } from '../../lib/audioCore.js';
 import { drawCircle, drawPlayhead } from './renderer.js';
 import { getCanvasPos } from './eventUtils.js';
 import { Circle } from './Circle.js';
@@ -140,7 +139,6 @@ export class CircleScore {
   }
 
   onPointerDown(e) {
-    ensureAudio();
     const { x, y } = getCanvasPos(this.canvas, e);
     if (e.pointerType === 'touch') {
       e.preventDefault();
@@ -194,7 +192,6 @@ export class CircleScore {
   }
 
   onDoubleClick(e) {
-    ensureAudio();
     const { x, y } = getCanvasPos(this.canvas, e);
     this.handleDoubleTap(x, y);
   }


### PR DESCRIPTION
## Summary
- Stop calling `ensureAudio()` on pointer down and double click; audio unlocking now handled by Player.
- Keep `ensureAudio()` in `Player.start` and `Player.startAudition` for autoplay policy compliance.

## Testing
- `node - <<'NODE' \n...\nNODE`

------
https://chatgpt.com/codex/tasks/task_e_68c2f476240c8320bd6a3c1c70c6ef24