### PR TITLE
Revert Tailwind CSS adoption

### DIFF
--- a/apps/circle-score/index.html
+++ b/apps/circle-score/index.html
@@ -1,18 +1,25 @@
 <!doctype html>
-<html lang="en" class="h-full">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <title>Circle Score — Log Spiral</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    html,body,#app{height:100%;margin:0;background:#111;color:#eee;font:16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif}
+    #app{display:flex;flex-direction:column}
+    canvas{flex:1;display:block;background:beige}
+    #controls{background:#222;padding:8px;display:flex;align-items:center;gap:8px}
+    #controls label{display:flex;align-items:center;gap:4px}
+    input[type=number]{width:40px}
+  </style>
 </head>
-<body class="h-full m-0 bg-neutral-900 text-neutral-100 font-sans">
-  <div id="app" class="h-full flex flex-col">
-    <canvas id="score" class="flex-1 block bg-neutral-200"></canvas>
-    <div id="controls" class="bg-neutral-800 p-2 flex items-center gap-2">
-      <button id="play" class="bg-neutral-700 rounded px-2 py-1">▶</button>
-      <label class="flex items-center gap-1">Beats: <input id="beatCount" class="w-10 text-neutral-800" type="number" min="0" max="9" value="4"></label>
-      <button id="delete" class="bg-neutral-700 rounded px-2 py-1">Delete</button>
+<body>
+  <div id="app">
+    <canvas id="score"></canvas>
+    <div id="controls">
+      <button id="play">▶</button>
+      <label>Beats: <input id="beatCount" type="number" min="0" max="9" value="4"></label>
+      <button id="delete">Delete</button>
     </div>
   </div>
   <script type="module" src="app.js"></script>

--- a/apps/pitch-harmonic-mixer/index.html
+++ b/apps/pitch-harmonic-mixer/index.html
@@ -5,7 +5,6 @@
   <title>Pitch Harmonic Mixer — Log Spiral</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="styles.css" />
-  <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body>
   <main>

--- a/apps/pitch-spiral/app.js
+++ b/apps/pitch-spiral/app.js
@@ -133,11 +133,10 @@ function updateControls() {
   controls.innerHTML = '';
   sorted.forEach((p,i) => {
     const row = document.createElement('div');
-    row.className = 'flex items-center gap-2 border border-neutral-600 p-1 rounded bg-neutral-700';
+    row.className = 'pitch-control';
     const mute = document.createElement('button');
     mute.textContent = 'M';
-    mute.className = 'bg-neutral-700 rounded px-2 py-1';
-    mute.classList.toggle('bg-neutral-600', p.muted);
+    mute.classList.toggle('active', p.muted);
     mute.addEventListener('click', () => {
       p.muted = !p.muted;
       if (p._osc) stopPitchSound(p);
@@ -145,8 +144,7 @@ function updateControls() {
     });
     const solo = document.createElement('button');
     solo.textContent = 'S';
-    solo.className = 'bg-neutral-700 rounded px-2 py-1';
-    solo.classList.toggle('bg-neutral-600', p.solo);
+    solo.classList.toggle('active', p.solo);
     solo.addEventListener('click', () => {
       p.solo = !p.solo;
       if (p._osc) stopPitchSound(p);
@@ -156,7 +154,6 @@ function updateControls() {
     label.innerHTML = `f<sub>${i}</sub>`;
     const slider = document.createElement('input');
     slider.type = 'range';
-    slider.className = 'flex-1';
     p._label = label;
     p._slider = slider;
     updatePitchControlColor(p);
@@ -212,7 +209,6 @@ function updateControls() {
     if (!p.fixed) {
       const rm = document.createElement('button');
       rm.textContent = '🗑';
-      rm.className = 'bg-neutral-700 rounded px-2 py-1';
       rm.addEventListener('click', () => removePitch(p.id));
       row.appendChild(rm);
     }
@@ -456,7 +452,7 @@ playBtn.addEventListener('click', () => {
 
 f0Btn.addEventListener('click', () => {
   f0DroneOn = !f0DroneOn;
-  f0Btn.classList.toggle('bg-neutral-600', f0DroneOn);
+  f0Btn.classList.toggle('active', f0DroneOn);
   f0Btn.innerHTML = `f<sub>0</sub> Drone ${f0DroneOn ? '🔊' : '🔇'}`;
   updateDrone();
 });

--- a/apps/pitch-spiral/index.html
+++ b/apps/pitch-spiral/index.html
@@ -1,26 +1,40 @@
 <!doctype html>
-<html lang="en" class="h-full">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <title>Pitch Spiral — Log Spiral</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    html,body,#app{height:100%;margin:0;background:#111;color:#eee;font:16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif}
+    #app{display:flex;flex-direction:column}
+    canvas{flex:3;display:block;background:#000}
+    #controls{flex:1;background:#222;padding:8px;overflow:auto}
+    #topControls{margin-bottom:8px;display:flex;align-items:center;gap:8px}
+    #topControls button{margin-right:0}
+    #topControls button.active{background:#555}
+    #topControls input[type=range]{width:100px}
+    #addSection{margin-bottom:8px;display:flex;align-items:center;gap:8px}
+    #pitchList{display:flex;flex-direction:column;gap:6px}
+    .pitch-control{display:flex;align-items:center;gap:8px;border:1px solid #444;padding:4px;border-radius:4px;background:#333}
+    .pitch-control button.active{background:#555}
+    .pitch-control input[type=range]{flex:1}
+  </style>
 </head>
-<body class="h-full m-0 bg-neutral-900 text-neutral-100 font-sans">
-  <div id="app" class="h-full flex flex-col">
-    <canvas id="spiral" class="flex-[3] block bg-black"></canvas>
-    <div id="controls" class="flex-1 bg-neutral-800 p-2 overflow-auto">
-      <div id="topControls" class="mb-2 flex flex-wrap items-center gap-2">
-        <button id="play" class="bg-neutral-700 rounded px-2 py-1">▶</button>
-        <button id="f0drone" class="bg-neutral-700 rounded px-2 py-1">f<sub>0</sub> Drone 🔇</button>
+<body>
+  <div id="app">
+    <canvas id="spiral"></canvas>
+    <div id="controls">
+      <div id="topControls">
+        <button id="play">▶</button>
+        <button id="f0drone">f<sub>0</sub> Drone 🔇</button>
         <span>🔊</span>
-        <input id="volume" class="w-24" type="range" min="0" max="100" value="50" />
+        <input id="volume" type="range" min="0" max="100" value="50" />
       </div>
-      <div id="addSection" class="mb-2 flex items-center gap-2">
+      <div id="addSection">
         <span>Add another Pitch</span>
-        <button id="add" class="bg-neutral-700 rounded px-2 py-1">+</button>
+        <button id="add">+</button>
       </div>
-      <div id="pitchList" class="flex flex-col gap-1.5"></div>
+      <div id="pitchList"></div>
     </div>
   </div>
   <script type="module" src="app.js"></script>

--- a/apps/spiral-trace/index.html
+++ b/apps/spiral-trace/index.html
@@ -5,7 +5,6 @@
   <title>Spiral Tracer — Log Harmonics</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="styles.css" />
-  <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body>
   <main>

--- a/apps/tempo-harmonic-mixer/index.html
+++ b/apps/tempo-harmonic-mixer/index.html
@@ -5,7 +5,6 @@
   <title>Tempo Harmonic Mixer — Log Spiral</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="styles.css" />
-  <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body>
   <main>

--- a/apps/tempo-spiral/app.js
+++ b/apps/tempo-spiral/app.js
@@ -132,11 +132,10 @@ function updateControls() {
   controls.innerHTML = '';
   sorted.forEach((p,i) => {
     const row = document.createElement('div');
-    row.className = 'flex items-center gap-2 border border-neutral-600 p-1 rounded bg-neutral-700';
+    row.className = 'tempo-control';
     const mute = document.createElement('button');
     mute.textContent = 'M';
-    mute.className = 'bg-neutral-700 rounded px-2 py-1';
-    mute.classList.toggle('bg-neutral-600', p.muted);
+    mute.classList.toggle('active', p.muted);
     mute.addEventListener('click', () => {
       p.muted = !p.muted;
       if (p._timer) stopTempoSound(p);
@@ -144,8 +143,7 @@ function updateControls() {
     });
     const solo = document.createElement('button');
     solo.textContent = 'S';
-    solo.className = 'bg-neutral-700 rounded px-2 py-1';
-    solo.classList.toggle('bg-neutral-600', p.solo);
+    solo.classList.toggle('active', p.solo);
     solo.addEventListener('click', () => {
       p.solo = !p.solo;
       if (p._timer) stopTempoSound(p);
@@ -155,7 +153,6 @@ function updateControls() {
     label.innerHTML = `f<sub>${i}</sub>`;
     const slider = document.createElement('input');
     slider.type = 'range';
-    slider.className = 'flex-1';
     p._label = label;
     p._slider = slider;
     updateTempoControlColor(p);
@@ -215,7 +212,6 @@ function updateControls() {
     if (!p.fixed) {
       const rm = document.createElement('button');
       rm.textContent = '🗑';
-      rm.className = 'bg-neutral-700 rounded px-2 py-1';
       rm.addEventListener('click', () => removeTempo(p.id));
       row.appendChild(rm);
     }
@@ -425,7 +421,7 @@ playBtn.addEventListener('click', () => {
 
 f0Btn.addEventListener('click', () => {
   f0MetronomeOn = !f0MetronomeOn;
-  f0Btn.classList.toggle('bg-neutral-600', f0MetronomeOn);
+  f0Btn.classList.toggle('active', f0MetronomeOn);
   f0Btn.innerHTML = `f<sub>0</sub> Metronome ${f0MetronomeOn ? '🔊' : '🔇'}`;
   updateMetronome();
 });

--- a/apps/tempo-spiral/index.html
+++ b/apps/tempo-spiral/index.html
@@ -1,28 +1,42 @@
 <!doctype html>
-<html lang="en" class="h-full">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <title>Tempo Spiral — Log Spiral</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    html,body,#app{height:100%;margin:0;background:#111;color:#eee;font:16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif}
+    #app{display:flex;flex-direction:column}
+    canvas{flex:3;display:block;background:#000}
+    #controls{flex:1;background:#222;padding:8px;overflow:auto}
+    #topControls{margin-bottom:8px;display:flex;align-items:center;gap:8px}
+    #topControls button{margin-right:0}
+    #topControls button.active{background:#555}
+    #topControls input[type=range]{width:100px}
+    #addSection{margin-bottom:8px;display:flex;align-items:center;gap:8px}
+    #tempoList{display:flex;flex-direction:column;gap:6px}
+    .tempo-control{display:flex;align-items:center;gap:8px;border:1px solid #444;padding:4px;border-radius:4px;background:#333}
+    .tempo-control button.active{background:#555}
+    .tempo-control input[type=range]{flex:1}
+  </style>
 </head>
-<body class="h-full m-0 bg-neutral-900 text-neutral-100 font-sans">
-  <div id="app" class="h-full flex flex-col">
-    <canvas id="spiral" class="flex-[3] block bg-black"></canvas>
-    <div id="controls" class="flex-1 bg-neutral-800 p-2 overflow-auto">
-      <div id="topControls" class="mb-2 flex flex-wrap items-center gap-2">
-        <button id="play" class="bg-neutral-700 rounded px-2 py-1">▶</button>
-        <button id="f0metro" class="bg-neutral-700 rounded px-2 py-1">f<sub>0</sub> Metronome 🔇</button>
+<body>
+  <div id="app">
+    <canvas id="spiral"></canvas>
+    <div id="controls">
+      <div id="topControls">
+        <button id="play">▶</button>
+        <button id="f0metro">f<sub>0</sub> Metronome 🔇</button>
         <span>Beats</span>
-        <input id="beats" class="w-24" type="range" min="1" max="16" value="4" />
+        <input id="beats" type="range" min="1" max="16" value="4" />
         <span>🔊</span>
-        <input id="volume" class="w-24" type="range" min="0" max="100" value="50" />
+        <input id="volume" type="range" min="0" max="100" value="50" />
       </div>
-      <div id="addSection" class="mb-2 flex items-center gap-2">
+      <div id="addSection">
         <span>Add another Tempo</span>
-        <button id="add" class="bg-neutral-700 rounded px-2 py-1">+</button>
+        <button id="add">+</button>
       </div>
-      <div id="tempoList" class="flex flex-col gap-1.5"></div>
+      <div id="tempoList"></div>
     </div>
   </div>
   <script type="module" src="app.js"></script>

--- a/index.html
+++ b/index.html
@@ -4,33 +4,39 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Log Spiral Apps</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    body{margin:0;background:#0b0b0b;color:#eaeaea;font:16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif}
+    main{max-width:860px;margin:64px auto;padding:0 20px}
+    a{color:#a7e0ff;text-decoration:none;border-bottom:1px dashed #2e4f5c}
+    a:hover{border-bottom-color:#a7e0ff}
+    .card{border:1px solid #2a2a2a;border-radius:12px;padding:20px;background:#101010;margin:12px 0}
+  </style>
 </head>
-<body class="m-0 bg-neutral-950 text-neutral-200 font-sans">
-  <main class="max-w-[860px] mx-auto my-16 px-5">
-    <h1 class="mb-6 text-2xl font-semibold">Log Spiral Tools</h1>
-    <div class="border border-neutral-800 rounded-xl p-5 bg-neutral-900 my-3">
-      <h2 class="text-xl font-medium"><a class="text-sky-300 no-underline border-b border-dashed border-slate-600 hover:border-sky-300" href="apps/spiral-trace/">Spiral Trace</a></h2>
+<body>
+  <main>
+    <h1>Log Spiral Tools</h1>
+    <div class="card">
+      <h2><a href="apps/spiral-trace/">Spiral Trace</a></h2>
       <p>Explore multi-octave harmonic relationships inside a logarithmic spiral.</p>
     </div>
-    <div class="border border-neutral-800 rounded-xl p-5 bg-neutral-900 my-3">
-      <h2 class="text-xl font-medium"><a class="text-sky-300 no-underline border-b border-dashed border-slate-600 hover:border-sky-300" href="apps/pitch-harmonic-mixer/">Pitch Harmonic Mixer</a></h2>
+    <div class="card">
+      <h2><a href="apps/pitch-harmonic-mixer/">Pitch Harmonic Mixer</a></h2>
       <p>Mix harmonics at various levels of loudness to create timbres</p>
     </div>
-    <div class="border border-neutral-800 rounded-xl p-5 bg-neutral-900 my-3">
-      <h2 class="text-xl font-medium"><a class="text-sky-300 no-underline border-b border-dashed border-slate-600 hover:border-sky-300" href="apps/tempo-harmonic-mixer/">Tempo Harmonic Mixer</a></h2>
+    <div class="card">
+      <h2><a href="apps/tempo-harmonic-mixer/">Tempo Harmonic Mixer</a></h2>
       <p>Explore polyrhythms by mixing tempo harmonics</p>
     </div>
-    <div class="border border-neutral-800 rounded-xl p-5 bg-neutral-900 my-3">
-      <h2 class="text-xl font-medium"><a class="text-sky-300 no-underline border-b border-dashed border-slate-600 hover:border-sky-300" href="apps/pitch-spiral/">Pitch Spiral</a></h2>
+    <div class="card">
+      <h2><a href="apps/pitch-spiral/">Pitch Spiral</a></h2>
       <p>Explore pitch relationships within a logarithmic single-octave spiral</p>
     </div>
-    <div class="border border-neutral-800 rounded-xl p-5 bg-neutral-900 my-3">
-      <h2 class="text-xl font-medium"><a class="text-sky-300 no-underline border-b border-dashed border-slate-600 hover:border-sky-300" href="apps/tempo-spiral/">Tempo Spiral</a></h2>
+    <div class="card">
+      <h2><a href="apps/tempo-spiral/">Tempo Spiral</a></h2>
       <p>Explore tempo relationships with rhythmic spirals and polyrhythms</p>
     </div>
-    <div class="border border-neutral-800 rounded-xl p-5 bg-neutral-900 my-3">
-      <h2 class="text-xl font-medium"><a class="text-sky-300 no-underline border-b border-dashed border-slate-600 hover:border-sky-300" href="apps/circle-score/">Circle Score</a></h2>
+    <div class="card">
+      <h2><a href="apps/circle-score/">Circle Score</a></h2>
       <p>Create rhythmic phrases as circles and lines.</p>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- Revert merge that introduced Tailwind CSS and restore pre-framework styling
- Replace Tailwind class usage with original custom classes in app controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b8921cd88320badc509365890135