### PR TITLE
Prevent manual audition during playback

### DIFF
--- a/apps/pitch-spiral/app.js
+++ b/apps/pitch-spiral/app.js
@@ -274,6 +274,7 @@ function stopTonicSound() {
 }
 
 function startPitchSound(p) {
+  if (playing) return;
   if (!isPitchEnabled(p)) return;
   const ctx = ensureAudio();
   const osc = ctx.createOscillator();


### PR DESCRIPTION
## Summary
- prevent manual pitch audition oscillators from starting while the sequencer is running to keep the loop balanced

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7892f62908320af6626077ce315d6