### PR TITLE
Add visualization mode tabs and 1D option for Layakine quadrants

### DIFF
--- a/apps/layakine/index.html
+++ b/apps/layakine/index.html
@@ -156,11 +156,60 @@
       justify-content: center;
       padding: 16px;
     }
+    .quadrant-tabs {
+      position: absolute;
+      display: inline-flex;
+      gap: 4px;
+      background: rgba(8, 8, 8, 0.85);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 999px;
+      padding: 4px;
+      z-index: 3;
+      box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
+      backdrop-filter: blur(6px);
+    }
+    .quadrant-tabs button {
+      background: transparent;
+      border: none;
+      color: #d8d8d8;
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      padding: 6px 12px;
+      border-radius: 999px;
+      cursor: pointer;
+      transition: color 0.2s ease, background 0.2s ease;
+    }
+    .quadrant-tabs button.active {
+      background: rgba(244, 244, 244, 0.9);
+      color: #111;
+    }
+    .quadrant-tabs button:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+    .quadrant-tabs.top-left {
+      top: 24px;
+      left: 24px;
+    }
+    .quadrant-tabs.top-right {
+      top: 24px;
+      left: calc(50% + 24px);
+    }
+    .quadrant-tabs.bottom-left {
+      top: calc(50% + 24px);
+      left: 24px;
+    }
+    .quadrant-tabs.bottom-right {
+      top: calc(50% + 24px);
+      left: calc(50% + 24px);
+    }
     canvas {
       width: 100%;
       height: 100%;
       border-radius: 12px;
       background: #080808;
+      z-index: 1;
     }
     #play-toggle {
       position: absolute;
@@ -179,6 +228,7 @@
       align-items: center;
       justify-content: center;
       transition: background 0.2s ease;
+      z-index: 4;
     }
     #play-toggle:hover {
       background: rgba(40, 40, 40, 0.85);
@@ -204,6 +254,26 @@
         padding-top: 16px;
       }
       #play-toggle { width: 56px; height: 56px; font-size: 1.2rem; }
+      .quadrant-tabs {
+        top: auto;
+        left: auto;
+      }
+      .quadrant-tabs.top-left {
+        top: 16px;
+        left: 16px;
+      }
+      .quadrant-tabs.top-right {
+        top: 16px;
+        left: calc(50% + 12px);
+      }
+      .quadrant-tabs.bottom-left {
+        top: calc(50% + 12px);
+        left: 16px;
+      }
+      .quadrant-tabs.bottom-right {
+        top: calc(50% + 12px);
+        left: calc(50% + 12px);
+      }
     }
   </style>
 </head>
@@ -225,6 +295,26 @@
       </div>
     </section>
     <div class="canvas-wrapper">
+      <div class="quadrant-tabs top-left" data-quadrant="gati">
+        <button class="mode-tab" data-quadrant="gati" data-mode="1d" type="button">1D</button>
+        <button class="mode-tab" data-quadrant="gati" data-mode="2d" type="button">2D</button>
+        <button class="mode-tab" data-quadrant="gati" data-mode="3d" type="button">3D</button>
+      </div>
+      <div class="quadrant-tabs top-right" data-quadrant="jati">
+        <button class="mode-tab" data-quadrant="jati" data-mode="1d" type="button">1D</button>
+        <button class="mode-tab" data-quadrant="jati" data-mode="2d" type="button">2D</button>
+        <button class="mode-tab" data-quadrant="jati" data-mode="3d" type="button">3D</button>
+      </div>
+      <div class="quadrant-tabs bottom-left" data-quadrant="laya">
+        <button class="mode-tab" data-quadrant="laya" data-mode="1d" type="button">1D</button>
+        <button class="mode-tab" data-quadrant="laya" data-mode="2d" type="button">2D</button>
+        <button class="mode-tab" data-quadrant="laya" data-mode="3d" type="button">3D</button>
+      </div>
+      <div class="quadrant-tabs bottom-right" data-quadrant="nadai">
+        <button class="mode-tab" data-quadrant="nadai" data-mode="1d" type="button">1D</button>
+        <button class="mode-tab" data-quadrant="nadai" data-mode="2d" type="button">2D</button>
+        <button class="mode-tab" data-quadrant="nadai" data-mode="3d" type="button">3D</button>
+      </div>
       <canvas id="layakine-canvas" width="800" height="800" aria-hidden="true"></canvas>
       <button id="play-toggle" type="button" aria-label="Play">▶</button>
     </div>


### PR DESCRIPTION
## Summary
- add quadrant-level tabs to switch between 1D, 2D, and 3D layouts in the Layakine app
- implement 1D visualisations driven by the quadrant cycle timing while keeping current shapes in the 2D mode
- ensure unspecified 3D mode renders a blank view for future development

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dba9f0cc448320ab4ea8d05d31d69d