### PR TITLE
Adjust gati 3D markers to rest on base plane

### DIFF
--- a/apps/layakine/app.js
+++ b/apps/layakine/app.js
@@ -535,9 +535,10 @@ function drawGatiQuadrant3d(config, elapsed) {
   const strokeColor = getStrokeColor('gati');
   const segmentColor = getSegmentColor('gati');
   const baseRadius = Math.min(width, height) * 0.32;
-  const markerHeight = Math.min(width, height) * 0.22;
-  const eventHeight = markerHeight;
   const baseMarkerRadius = Math.max(3, canvas.width * 0.0045);
+  const surfaceHeight = Math.max(2, baseMarkerRadius * 0.6);
+  const markerHeight = surfaceHeight;
+  const eventHeight = surfaceHeight;
 
   const project = (point, heightOffset = 0) =>
     projectPointToIsometric(point, baseCenter, isoOrigin, scale, heightOffset);


### PR DESCRIPTION
## Summary
- reduce the height offset for the 3D gati markers so shapes rest directly on the base plane

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbf5495cf8832087b12916f6febc91