### PR TITLE
Add 3Dbeta donut visualization for jati quadrant

### DIFF
--- a/apps/layakine/index.html
+++ b/apps/layakine/index.html
@@ -304,6 +304,7 @@
         <button class="mode-tab" data-quadrant="jati" data-mode="1d" type="button">1D</button>
         <button class="mode-tab" data-quadrant="jati" data-mode="2d" type="button">2D</button>
         <button class="mode-tab" data-quadrant="jati" data-mode="3d" type="button">3D</button>
+        <button class="mode-tab" data-quadrant="jati" data-mode="3dbeta" type="button">3Dbeta</button>
       </div>
       <div class="quadrant-tabs bottom-left" data-quadrant="laya">
         <button class="mode-tab" data-quadrant="laya" data-mode="1d" type="button">1D</button>


### PR DESCRIPTION
## Summary
- add a 3Dbeta mode button to the jati quadrant controls
- render a donut-style 3D beta visualization that revolves the existing 2D jati shape
- carry over timing progress and markers onto the new donut surface

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dccca6b3188320a272928890849a77