### PR TITLE
Show first jati copy in condensed 3D beta view

### DIFF
--- a/apps/layakine/app.js
+++ b/apps/layakine/app.js
@@ -1698,8 +1698,11 @@ function drawJatiQuadrant3dBeta(config, elapsed) {
     overallProgress = (elapsed % shapeCycle) / shapeCycle;
   }
 
+  const jatiGroupSize = Math.max(1, jatiSegmentCount);
+
   drawInfos.forEach((info) => {
-    if (!showFullScene) {
+    const isGroupStart = info.index % jatiGroupSize === 0;
+    if (!showFullScene && !isGroupStart) {
       return;
     }
     drawRadialLine(info);


### PR DESCRIPTION
## Summary
- ensure the condensed 3D beta jati view still renders the first copy of each jati group so the structure remains visible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd1ada6838832087ef7f1b16125f52