### PR TITLE
Adjust jati 3D mode and stationary marker alignment

### DIFF
--- a/apps/layakine/index.html
+++ b/apps/layakine/index.html
@@ -342,8 +342,8 @@
       <div class="quadrant-tabs top-right" data-quadrant="jati">
         <button class="mode-tab" data-quadrant="jati" data-mode="1d" type="button">1D</button>
         <button class="mode-tab" data-quadrant="jati" data-mode="2d" type="button">2D</button>
+        <button class="mode-tab" data-quadrant="jati" data-mode="3d-deprecated" type="button">3D(deprecated)</button>
         <button class="mode-tab" data-quadrant="jati" data-mode="3d" type="button">3D</button>
-        <button class="mode-tab" data-quadrant="jati" data-mode="3dbeta" type="button">3Dbeta</button>
       </div>
       <div class="quadrant-tabs bottom-left" data-quadrant="laya">
         <button class="mode-tab" data-quadrant="laya" data-mode="1d" type="button">1D</button>


### PR DESCRIPTION
## Summary
- align the stationary jati sound marker with the leading edge corner in the 3D view when copies share an edge
- promote the updated jati 3D experience to the primary "3D" mode and label the legacy rendering as "3D(deprecated)"

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd466ee3448320ad9e7adddcdd7871