### PR TITLE
Remove deprecated Layakine jati 3D view

### DIFF
--- a/apps/layakine/app.js
+++ b/apps/layakine/app.js
@@ -2324,16 +2324,6 @@ function drawQuadrant(name, config, elapsed) {
     return;
   }
 
-  if (mode === '3d-deprecated' && name === 'jati') {
-    drawJatiQuadrant3d({
-      orientation,
-      view2d,
-      cycleDuration,
-      gatiCount: config.gatiCount,
-    }, elapsed);
-    return;
-  }
-
   if (mode === '3d') {
     if (name === 'gati') {
       drawGatiQuadrant3d({ orientation, view2d, cycleDuration }, elapsed);

--- a/apps/layakine/index.html
+++ b/apps/layakine/index.html
@@ -342,7 +342,6 @@
       <div class="quadrant-tabs top-right" data-quadrant="jati">
         <button class="mode-tab" data-quadrant="jati" data-mode="1d" type="button">1D</button>
         <button class="mode-tab" data-quadrant="jati" data-mode="2d" type="button">2D</button>
-        <button class="mode-tab" data-quadrant="jati" data-mode="3d-deprecated" type="button">3D(deprecated)</button>
         <button class="mode-tab" data-quadrant="jati" data-mode="3d" type="button">3D</button>
       </div>
       <div class="quadrant-tabs bottom-left" data-quadrant="laya">


### PR DESCRIPTION
## Summary
- remove the deprecated Jati 3D(deprecated) toggle from the Layakine UI
- drop the rendering code path that handled the deprecated mode

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd49fc97988320893de84df0572d75