### PR TITLE
Extend Sa slider range

### DIFF
--- a/apps/shruti22/app.js
+++ b/apps/shruti22/app.js
@@ -364,7 +364,7 @@ function updateControls() {
     updatePitchControlColor(p);
     if (p.fixed) {
       slider.min = 80;
-      slider.max = 160;
+      slider.max = 640;
       slider.value = tonicHz;
       const handleInput = e => {
         tonicHz = parseFloat(e.target.value);


### PR DESCRIPTION
## Summary
- extend the Sa frequency slider to cover two additional higher octaves for tonic selection

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd5127e23c8320bfd80230768bcbaf