### PR TITLE
Expand f0 slider range

### DIFF
--- a/apps/pitch-spiral/app.js
+++ b/apps/pitch-spiral/app.js
@@ -276,7 +276,7 @@ function updateControls() {
     updatePitchControlColor(p);
     if (p.fixed) {
       slider.min = 80;
-      slider.max = 160;
+      slider.max = 640;
       slider.value = tonicHz;
       const handleInput = e => {
         tonicHz = parseFloat(e.target.value);


### PR DESCRIPTION
## Summary
- extend the tonic frequency slider ceiling to reach two higher octaves

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd5406163083209c449a2a045aa77f