### PR TITLE
Revise nadai slider and 2D logic

### DIFF
--- a/apps/layakine/index.html
+++ b/apps/layakine/index.html
@@ -367,8 +367,8 @@
       <div class="control" data-kind="nadai">
         <label for="nadai">Nadai</label>
         <button class="mute" data-target="nadai" aria-pressed="false">Mute</button>
-        <input id="nadai" type="range" min="0" max="24" step="1" value="12" />
-        <span class="value" data-for="nadai">1</span>
+        <input id="nadai" type="range" min="1" max="13" step="1" value="5" />
+        <span class="value" data-for="nadai">5</span>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- change the nadai control to use a 1–13 integer slider and display the raw value
- rework nadai timing so its cycle matches the jati cycle and play each subdivision
- update the nadai 2D view to select shapes and stationary markers from the slider value

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de306e32fc8320b321c6e21443afdc