### PR TITLE
Adjust nadai defaults and 3D animation

### DIFF
--- a/apps/layakine/index.html
+++ b/apps/layakine/index.html
@@ -367,8 +367,8 @@
       <div class="control" data-kind="nadai">
         <label for="nadai">Nadai</label>
         <button class="mute" data-target="nadai" aria-pressed="false">Mute</button>
-        <input id="nadai" type="range" min="1" max="13" step="1" value="5" />
-        <span class="value" data-for="nadai">5</span>
+        <input id="nadai" type="range" min="1" max="13" step="1" value="1" />
+        <span class="value" data-for="nadai">1</span>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- set the default nadai slider value to 1 so the quadrant starts from a single pulse
- rework the nadai 3D renderer to mirror the jati layout, creating a copy per gati and pacing each copy with the 2D nadai cycle
- pass the current gati count through the quadrant config so the 3D renderer can size and animate its copies correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de3b2377408320b363b5cb9ffa7665