### PR TITLE
Highlight first event markers in gati and nadai 2D views

### DIFF
--- a/apps/layakine/app.js
+++ b/apps/layakine/app.js
@@ -403,6 +403,37 @@ function getSegmentColor(name) {
   }
 }
 
+function lightenColor(hex, amount = 0.25) {
+  const normalized = hex.replace('#', '');
+  if (normalized.length !== 6) {
+    return hex;
+  }
+  const r = parseInt(normalized.slice(0, 2), 16);
+  const g = parseInt(normalized.slice(2, 4), 16);
+  const b = parseInt(normalized.slice(4, 6), 16);
+  if ([r, g, b].some((component) => Number.isNaN(component))) {
+    return hex;
+  }
+  const mix = (component) => {
+    const value = Math.round(component + (255 - component) * amount);
+    return Math.max(0, Math.min(255, value));
+  };
+  const toHex = (component) => component.toString(16).padStart(2, '0');
+  const lightened = `#${toHex(mix(r))}${toHex(mix(g))}${toHex(mix(b))}`;
+  return lightened;
+}
+
+function getFirstSoundMarkerColor(name, baseColor) {
+  switch (name) {
+    case 'gati':
+      return lightenColor(baseColor, 0.35);
+    case 'nadai':
+      return lightenColor(baseColor, 0.3);
+    default:
+      return baseColor;
+  }
+}
+
 function getStrokeColor(name) {
   switch (name) {
     case 'laya':
@@ -423,6 +454,7 @@ function drawQuadrantShape(name, config, elapsed) {
   ctx.lineWidth = 3;
   const strokeColor = ctx.strokeStyle;
   const color = getSegmentColor(name);
+  const firstEventColor = getFirstSoundMarkerColor(name, color);
   const eventRadius = ctx.lineWidth * 2;
   if (config.shape === 'line') {
     const [start, end] = getLinePoints(config.orientation);
@@ -430,7 +462,8 @@ function drawQuadrantShape(name, config, elapsed) {
 
     const eventPoints = getLineSoundPoints(start, end, config, config.soundMarkers);
     eventPoints.forEach((pt, index) => {
-      drawEventMarker(pt, strokeColor, color, eventRadius, {
+      const fillColor = config.highlightFirstEvent && index === 0 ? firstEventColor : color;
+      drawEventMarker(pt, strokeColor, fillColor, eventRadius, {
         highlight: !!config.highlightFirstEvent && index === 0,
       });
     });
@@ -468,7 +501,8 @@ function drawQuadrantShape(name, config, elapsed) {
     drawPolygon(points);
     const eventPoints = getPolygonSoundPoints(points, config.soundMarkers);
     eventPoints.forEach((pt, index) => {
-      drawEventMarker(pt, strokeColor, color, eventRadius, {
+      const fillColor = config.highlightFirstEvent && index === 0 ? firstEventColor : color;
+      drawEventMarker(pt, strokeColor, fillColor, eventRadius, {
         highlight: !!config.highlightFirstEvent && index === 0,
       });
     });
@@ -487,7 +521,8 @@ function drawQuadrantShape(name, config, elapsed) {
     ctx.arc(center.x, center.y, radius, 0, Math.PI * 2);
     ctx.stroke();
 
-    drawEventMarker(top, strokeColor, color, eventRadius, {
+    const fillColor = config.highlightFirstEvent ? firstEventColor : color;
+    drawEventMarker(top, strokeColor, fillColor, eventRadius, {
       highlight: !!config.highlightFirstEvent,
     });
 

--- a/apps/layakine/app.js
+++ b/apps/layakine/app.js
@@ -335,23 +335,40 @@ function drawCircle(point, color) {
 
 function drawEventMarker(point, strokeColor, fillColor, radius, options = {}) {
   const { highlight = false } = options;
+  const markerRadius = highlight ? radius * 1.2 : radius;
   if (highlight) {
     ctx.save();
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.12)';
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.28)';
     ctx.beginPath();
-    ctx.arc(point.x, point.y, radius * 1.6, 0, Math.PI * 2);
+    ctx.arc(point.x, point.y, markerRadius * 2.1, 0, Math.PI * 2);
     ctx.fill();
+    ctx.restore();
+
+    ctx.save();
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.75)';
+    ctx.lineWidth = Math.max(2, markerRadius * 0.6);
+    ctx.beginPath();
+    ctx.arc(point.x, point.y, markerRadius * 1.45, 0, Math.PI * 2);
+    ctx.stroke();
     ctx.restore();
   }
   ctx.save();
   ctx.fillStyle = fillColor;
   ctx.strokeStyle = strokeColor;
-  ctx.lineWidth = Math.max(1, radius * 0.5);
+  ctx.lineWidth = Math.max(1.5, markerRadius * 0.45);
   ctx.beginPath();
-  ctx.arc(point.x, point.y, radius, 0, Math.PI * 2);
+  ctx.arc(point.x, point.y, markerRadius, 0, Math.PI * 2);
   ctx.fill();
   ctx.stroke();
   ctx.restore();
+  if (highlight) {
+    ctx.save();
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.88)';
+    ctx.beginPath();
+    ctx.arc(point.x, point.y, markerRadius * 0.45, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+  }
 }
 
 function getLineSoundPoints(start, end, config, soundMarkers) {
@@ -426,9 +443,9 @@ function lightenColor(hex, amount = 0.25) {
 function getFirstSoundMarkerColor(name, baseColor) {
   switch (name) {
     case 'gati':
-      return lightenColor(baseColor, 0.35);
+      return lightenColor(baseColor, 0.6);
     case 'nadai':
-      return lightenColor(baseColor, 0.3);
+      return lightenColor(baseColor, 0.55);
     default:
       return baseColor;
   }

--- a/apps/layakine/app.js
+++ b/apps/layakine/app.js
@@ -338,17 +338,17 @@ function drawEventMarker(point, strokeColor, fillColor, radius, options = {}) {
   const markerRadius = highlight ? radius * 1.2 : radius;
   if (highlight) {
     ctx.save();
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.28)';
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.2)';
     ctx.beginPath();
-    ctx.arc(point.x, point.y, markerRadius * 2.1, 0, Math.PI * 2);
+    ctx.arc(point.x, point.y, markerRadius * 1.9, 0, Math.PI * 2);
     ctx.fill();
     ctx.restore();
 
     ctx.save();
-    ctx.strokeStyle = 'rgba(255, 255, 255, 0.75)';
-    ctx.lineWidth = Math.max(2, markerRadius * 0.6);
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.65)';
+    ctx.lineWidth = Math.max(1.5, markerRadius * 0.4);
     ctx.beginPath();
-    ctx.arc(point.x, point.y, markerRadius * 1.45, 0, Math.PI * 2);
+    ctx.arc(point.x, point.y, markerRadius * 1.35, 0, Math.PI * 2);
     ctx.stroke();
     ctx.restore();
   }
@@ -363,9 +363,9 @@ function drawEventMarker(point, strokeColor, fillColor, radius, options = {}) {
   ctx.restore();
   if (highlight) {
     ctx.save();
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.88)';
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.65)';
     ctx.beginPath();
-    ctx.arc(point.x, point.y, markerRadius * 0.45, 0, Math.PI * 2);
+    ctx.arc(point.x, point.y, markerRadius * 0.38, 0, Math.PI * 2);
     ctx.fill();
     ctx.restore();
   }
@@ -443,9 +443,9 @@ function lightenColor(hex, amount = 0.25) {
 function getFirstSoundMarkerColor(name, baseColor) {
   switch (name) {
     case 'gati':
-      return lightenColor(baseColor, 0.6);
+      return lightenColor(baseColor, 0.4);
     case 'nadai':
-      return lightenColor(baseColor, 0.55);
+      return lightenColor(baseColor, 0.38);
     default:
       return baseColor;
   }


### PR DESCRIPTION
## Summary
- add helper utilities to lighten quadrant colors for first sound markers
- use the lighter colors for the starting sound circle in the gati and nadai 2D shapes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de69fc30e48320a18318521713af81