### PR TITLE
Adjust highlight opacity for jati and nadai 3D views

### DIFF
--- a/apps/layakine/app.js
+++ b/apps/layakine/app.js
@@ -1706,7 +1706,7 @@ function drawJatiQuadrant3dBeta(config, elapsed) {
     const baseAlpha = showFullScene ? frontShade : frontShade + 0.12;
     const strokeAlpha = isActive ? 0.9 : info.facing ? 0.65 : 0.4;
     const highlightFirstCopy = info.index === 0;
-    const highlightStrokeStyle = 'rgba(255, 255, 255, 0.92)';
+    const highlightStrokeStyle = 'rgba(255, 255, 255, 0.46)';
     const highlightLineWidth = Math.max(0.7, canvas.width * 0.001);
     if (isLineShape && info.lineSegment) {
       ctx.save();
@@ -2173,7 +2173,7 @@ function drawNadaiQuadrant3d(config, elapsed) {
     const baseAlpha = showFullScene ? frontShade : frontShade + 0.12;
     const strokeAlpha = isActive ? 0.9 : info.facing ? 0.65 : 0.4;
     const highlightFirstCopy = info.index === 0;
-    const highlightStrokeStyle = 'rgba(255, 255, 255, 0.92)';
+    const highlightStrokeStyle = 'rgba(255, 255, 255, 0.46)';
     const highlightLineWidth = Math.max(0.7, canvas.width * 0.001);
     if (isLineShape && info.lineSegment) {
       ctx.save();


### PR DESCRIPTION
## Summary
- reduce the white highlight stroke opacity for the first copy in the jati 3D view
- reduce the white highlight stroke opacity for the first copy in the nadai 3D view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de7ba82e7483209b18cd01dea138ee