### PR TITLE
Keep Layakine mode tabs within quadrant bounds

### DIFF
--- a/apps/layakine/app.js
+++ b/apps/layakine/app.js
@@ -286,6 +286,7 @@ function updateQuadrantTabSizing(rect) {
 
   const desiredMarginX = clamp(quadrantWidth * 0.08, 12, 40);
   const desiredMarginY = clamp(quadrantHeight * 0.08, 12, 40);
+  const maxTabWidthRatio = 0.85;
   const availableMarginX = Math.max(0, quadrantWidth / 2 - 6);
   const availableMarginY = Math.max(0, quadrantHeight / 2 - 6);
   const minimumMarginX = availableMarginX > 0 ? clamp(quadrantWidth * 0.02, 6, 14) : 0;
@@ -409,7 +410,7 @@ function updateQuadrantTabSizing(rect) {
     const gatiBounds = quadrantBounds.gati || fallbackBounds;
     const gatiMaxWidth = Math.min(
       Math.max(0, gatiBounds.right - gatiBounds.left),
-      Math.max(0, quadrantWidth * 0.4),
+      Math.max(0, quadrantWidth * maxTabWidthRatio),
     );
     const gatiMetrics = computeMetricsForTab(gatiEntry, gatiBounds, null, gatiMaxWidth);
     metricsByTab.set(gatiEntry.tab, gatiMetrics);
@@ -423,7 +424,7 @@ function updateQuadrantTabSizing(rect) {
     const bounds = quadrantBounds[entry.tab.dataset.quadrant] || fallbackBounds;
     const maxWidth = Math.min(
       Math.max(0, bounds.right - bounds.left),
-      Math.max(0, quadrantWidth * 0.4),
+      Math.max(0, quadrantWidth * maxTabWidthRatio),
     );
     const metrics = computeMetricsForTab(entry, bounds, gatiTargetHeight, maxWidth);
     metricsByTab.set(entry.tab, metrics);

--- a/apps/layakine/index.html
+++ b/apps/layakine/index.html
@@ -177,7 +177,11 @@
       --quadrant-tab-padding: clamp(3px, 0.6vw, 8px);
       position: absolute;
       display: inline-flex;
+      flex-wrap: wrap;
       gap: var(--quadrant-tab-gap);
+      justify-content: center;
+      align-content: center;
+      align-items: center;
       background: rgba(8, 8, 8, 0.85);
       border: 1px solid rgba(255, 255, 255, 0.08);
       border-radius: 999px;


### PR DESCRIPTION
## Summary
- allow Layakine quadrant tab groups to wrap and center their buttons so labels stay inside the capsule
- relax the maximum tab width calculation so all three mode options remain visible across screen sizes

## Testing
- Manual QA: opened `apps/layakine/index.html` in a 390x844 viewport

------
https://chatgpt.com/codex/tasks/task_e_68dea311a84c8320af1b02c5e75e042f