### PR TITLE
Fix Layakine 3D renderer syntax error

### DIFF
--- a/apps/layakine/render/draw3d.js
+++ b/apps/layakine/render/draw3d.js
@@ -418,18 +418,6 @@ function drawGatiQuadrant3dInternal(config, elapsed) {
     drawCircleShape();
   }
 }
-      baseOpacity: 0.32,
-    });
-  };
-
-  if (view2d.shape === 'line') {
-    drawLineShape();
-  } else if (view2d.shape === 'polygon') {
-    drawPolygonShape();
-  } else if (view2d.shape === 'circle') {
-    drawCircleShape();
-  }
-}
 
 function drawJatiQuadrant3dInternal(config, elapsed) {
   const ctx = ctxRef;


### PR DESCRIPTION
## Summary
- remove the duplicated block in the Layakine 3D renderer that caused a syntax error and prevented the canvas/audio from initializing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df6079080883209d752f180245aaaa