### PR TITLE
Simplify Layakine quadrant tab layout

### DIFF
--- a/apps/layakine/app.js
+++ b/apps/layakine/app.js
@@ -35,13 +35,6 @@ let audioEngine = null;
 
 const getElapsed = () => (audioEngine ? audioEngine.getElapsed() : 0);
 
-function clamp(value, min, max) {
-  if (!Number.isFinite(value)) {
-    return min;
-  }
-  return Math.min(Math.max(value, min), max);
-}
-
 function lightenColor(hex, amount = 0.25) {
   const normalized = hex.replace('#', '');
   if (normalized.length !== 6) {
@@ -114,294 +107,25 @@ function formatLayaValue(value) {
   return `${value} bpm`;
 }
 
-const QUADRANT_ALIGNMENT = {
-  gati: { horizontal: 'left', vertical: 'top' },
-  jati: { horizontal: 'right', vertical: 'top' },
-  laya: { horizontal: 'left', vertical: 'top' },
-  nadai: { horizontal: 'right', vertical: 'top' },
-};
-
-function computeQuadrantBounds(rect) {
-  if (!rect) {
-    return null;
-  }
-
-  const { width, height, left: canvasLeft, top: canvasTop, right: canvasRight, bottom: canvasBottom } = rect;
-  const quadrantWidth = width / 2;
-  const quadrantHeight = height / 2;
-
-  const desiredMarginX = clamp(quadrantWidth * 0.08, 12, 40);
-  const desiredMarginY = clamp(quadrantHeight * 0.08, 12, 40);
-  const availableMarginX = Math.max(0, quadrantWidth / 2 - 6);
-  const availableMarginY = Math.max(0, quadrantHeight / 2 - 6);
-  const minimumMarginX = availableMarginX > 0 ? clamp(quadrantWidth * 0.02, 6, 14) : 0;
-  const minimumMarginY = availableMarginY > 0 ? clamp(quadrantHeight * 0.02, 6, 14) : 0;
-  const safeMarginX = availableMarginX > 0 ? clamp(desiredMarginX, minimumMarginX, availableMarginX) : 0;
-  const safeMarginY = availableMarginY > 0 ? clamp(desiredMarginY, minimumMarginY, availableMarginY) : 0;
-
-  const canvasCenterX = canvasLeft + quadrantWidth;
-  const canvasCenterY = canvasTop + quadrantHeight;
-
-  const quadrantBounds = {
-    gati: {
-      left: canvasLeft + safeMarginX,
-      right: canvasCenterX - safeMarginX,
-      top: canvasTop + safeMarginY,
-      bottom: canvasCenterY - safeMarginY,
-    },
-    jati: {
-      left: canvasCenterX + safeMarginX,
-      right: canvasRight - safeMarginX,
-      top: canvasTop + safeMarginY,
-      bottom: canvasCenterY - safeMarginY,
-    },
-    laya: {
-      left: canvasLeft + safeMarginX,
-      right: canvasCenterX - safeMarginX,
-      top: canvasCenterY + safeMarginY,
-      bottom: canvasBottom - safeMarginY,
-    },
-    nadai: {
-      left: canvasCenterX + safeMarginX,
-      right: canvasRight - safeMarginX,
-      top: canvasCenterY + safeMarginY,
-      bottom: canvasBottom - safeMarginY,
-    },
-  };
-
-  const fallbackBounds = {
-    left: canvasLeft + safeMarginX,
-    right: canvasRight - safeMarginX,
-    top: canvasTop + safeMarginY,
-    bottom: canvasBottom - safeMarginY,
-  };
-
-  return {
-    canvasLeft,
-    canvasTop,
-    canvasRight,
-    canvasBottom,
-    quadrantWidth,
-    quadrantHeight,
-    quadrantBounds,
-    fallbackBounds,
-  };
-}
-
-function measureTabMetrics(entry, bounds, options = {}) {
-  const { targetHeight = null, maxWidth: maxWidthOverride = null, maxScale = 1.5 } = options;
-
-  const availableWidth = Math.max(0, bounds.right - bounds.left);
-  const constrainedWidth =
-    maxWidthOverride !== null && maxWidthOverride !== undefined
-      ? Math.max(0, Math.min(availableWidth, maxWidthOverride))
-      : availableWidth;
-  const availableHeight = Math.max(0, bounds.bottom - bounds.top);
-
-  if (!entry || !entry.naturalWidth || !entry.naturalHeight) {
-    return {
-      scale: 1,
-      width: entry?.naturalWidth ?? constrainedWidth,
-      height: entry?.naturalHeight ?? availableHeight,
-      maxWidth: constrainedWidth,
-      maxHeight: availableHeight,
-    };
-  }
-
-  const widthScale =
-    entry.naturalWidth > 0
-      ? constrainedWidth > 0
-        ? constrainedWidth / entry.naturalWidth
-        : 0
-      : 1;
-  const heightScale =
-    entry.naturalHeight > 0
-      ? availableHeight > 0
-        ? availableHeight / entry.naturalHeight
-        : 0
-      : 1;
-
-  let scale = Math.min(widthScale, heightScale, maxScale);
-
-  if (targetHeight && entry.naturalHeight > 0) {
-    const matchScale = targetHeight / entry.naturalHeight;
-    if (Number.isFinite(matchScale) && matchScale > 0) {
-      scale = Math.min(scale, matchScale, maxScale);
-    }
-  }
-
-  if (!Number.isFinite(scale) || scale <= 0) {
-    const fallbackScale = Math.max(widthScale, heightScale, 0);
-    scale = Number.isFinite(fallbackScale) ? Math.min(fallbackScale, maxScale) : 0;
-  }
-
-  if (!Number.isFinite(scale) || scale < 0) {
-    scale = 0;
-  }
-
-  return {
-    scale,
-    width: entry.naturalWidth * scale,
-    height: entry.naturalHeight * scale,
-    maxWidth: constrainedWidth,
-    maxHeight: availableHeight,
-  };
-}
-
-function computeTabScaleCompression(rect = null) {
-  const viewportHeight =
-    typeof window !== 'undefined' && typeof window.innerHeight === 'number'
-      ? window.innerHeight
-      : rect?.height ?? 0;
-
-  if (!(viewportHeight > 0)) {
-    return 1;
-  }
-
-  const normalizedHeight = Math.min(viewportHeight, 500) / 500;
-  const exponent = 4.5;
-  const compression = normalizedHeight ** exponent;
-  const minCompression = 0.1;
-
-  return clamp(compression, minCompression, 1);
-}
-
-function applyTabScaleCompression(metrics, compression) {
-  if (!metrics || !(compression > 0)) {
-    return metrics;
-  }
-
-  return {
-    ...metrics,
-    scale: metrics.scale * compression,
-    width: metrics.width * compression,
-    height: metrics.height * compression,
-  };
-}
-
-function resetQuadrantTabStyles(tabs) {
-  return tabs.map((tab) => {
-    tab.style.setProperty('--quadrant-tab-scale', '1');
-    tab.style.setProperty('--quadrant-tab-translate-x', '0px');
-    tab.style.setProperty('--quadrant-tab-translate-y', '0px');
-    tab.style.left = '';
-    tab.style.right = '';
-    tab.style.top = '';
-    tab.style.bottom = '';
-
-    const { width: naturalWidth, height: naturalHeight } = tab.getBoundingClientRect();
-    return { tab, naturalWidth, naturalHeight };
-  });
-}
-
-function applyQuadrantTabPositions(tabs, metricsByTab, geometry, alignmentByQuadrant = QUADRANT_ALIGNMENT) {
-  const { quadrantBounds, fallbackBounds, canvasLeft, canvasTop, canvasRight } = geometry;
-
-  tabs.forEach((tab) => {
-    const quadrant = tab.dataset.quadrant;
-    const bounds = quadrantBounds[quadrant] || fallbackBounds;
-    const metrics =
-      metricsByTab.get(tab) ||
-      {
-        scale: 1,
-        width: 0,
-        height: 0,
-        maxWidth: Math.max(0, bounds.right - bounds.left),
-        maxHeight: Math.max(0, bounds.bottom - bounds.top),
-      };
-    const alignment = alignmentByQuadrant[quadrant] || alignmentByQuadrant.gati;
-
-    const availableWidth = Number.isFinite(metrics.maxWidth)
-      ? metrics.maxWidth
-      : Math.max(0, bounds.right - bounds.left);
-    const availableHeight = Number.isFinite(metrics.maxHeight)
-      ? metrics.maxHeight
-      : Math.max(0, bounds.bottom - bounds.top);
-
-    const width = Math.min(metrics.width, availableWidth);
-    const height = Math.min(metrics.height, availableHeight);
-
-    let targetLeft = alignment.horizontal === 'right' ? bounds.right - width : bounds.left;
-    let targetTop = alignment.vertical === 'bottom' ? bounds.bottom - height : bounds.top;
-
-    targetLeft = clamp(targetLeft, bounds.left, bounds.right - width);
-    targetTop = clamp(targetTop, bounds.top, bounds.bottom - height);
-
-    const relativeLeft = targetLeft - canvasLeft;
-    const relativeTop = targetTop - canvasTop;
-    const relativeRight = canvasRight - (targetLeft + width);
-
-    const maxWidthValue = availableWidth > 0 ? `${availableWidth}px` : 'none';
-    const maxHeightValue = availableHeight > 0 ? `${availableHeight}px` : 'none';
-    tab.style.setProperty('--quadrant-tab-max-width', maxWidthValue);
-    tab.style.setProperty('--quadrant-tab-max-height', maxHeightValue);
-    tab.style.setProperty('--quadrant-tab-scale', `${metrics.scale}`);
-    tab.style.setProperty('--quadrant-tab-translate-x', '0px');
-    tab.style.setProperty('--quadrant-tab-translate-y', '0px');
-    tab.style.top = `${relativeTop}px`;
-    tab.style.bottom = 'auto';
-    if (alignment.horizontal === 'right') {
-      tab.style.right = `${relativeRight}px`;
-      tab.style.left = 'auto';
-      tab.style.transformOrigin = 'top right';
-    } else {
-      tab.style.left = `${relativeLeft}px`;
-      tab.style.right = 'auto';
-      tab.style.transformOrigin = 'top left';
-    }
-  });
-}
-
 function updateQuadrantTabSizing(rect) {
   if (!rect) {
     return;
   }
 
-  const geometry = computeQuadrantBounds(rect);
-  if (!geometry) {
-    return;
-  }
+  const quadrantWidth = rect.width / 2;
+  const quadrantHeight = rect.height / 2;
+  const tabWidth = quadrantWidth / 5;
+  const tabHeight = quadrantHeight / 20;
 
-  const viewportCompression = computeTabScaleCompression(rect);
-  const maxTabWidthRatio = 0.85;
-  const resetMeasurements = resetQuadrantTabStyles(quadrantTabs);
-
-  const metricsByTab = new Map();
-  const gatiEntry = resetMeasurements.find(({ tab }) => tab.dataset.quadrant === 'gati');
-  let gatiTargetHeightRaw = null;
-
-  if (gatiEntry) {
-    const gatiBounds = geometry.quadrantBounds.gati || geometry.fallbackBounds;
-    const gatiMaxWidth = Math.min(
-      Math.max(0, gatiBounds.right - gatiBounds.left),
-      Math.max(0, geometry.quadrantWidth * maxTabWidthRatio),
-    );
-    const gatiRawMetrics = measureTabMetrics(gatiEntry, gatiBounds, {
-      maxWidth: gatiMaxWidth,
+  quadrantTabs.forEach((tabContainer) => {
+    tabContainer.style.setProperty('--quadrant-tab-width', `${tabWidth}px`);
+    tabContainer.style.setProperty('--quadrant-tab-height', `${tabHeight}px`);
+    const buttons = tabContainer.querySelectorAll('.mode-tab');
+    buttons.forEach((button) => {
+      button.style.width = `${tabWidth}px`;
+      button.style.height = `${tabHeight}px`;
     });
-    const gatiMetrics = applyTabScaleCompression(gatiRawMetrics, viewportCompression);
-    metricsByTab.set(gatiEntry.tab, gatiMetrics);
-    gatiTargetHeightRaw = gatiRawMetrics.height;
-  }
-
-  resetMeasurements.forEach((entry) => {
-    if (metricsByTab.has(entry.tab)) {
-      return;
-    }
-    const bounds = geometry.quadrantBounds[entry.tab.dataset.quadrant] || geometry.fallbackBounds;
-    const maxWidth = Math.min(
-      Math.max(0, bounds.right - bounds.left),
-      Math.max(0, geometry.quadrantWidth * maxTabWidthRatio),
-    );
-    const rawMetrics = measureTabMetrics(entry, bounds, {
-      targetHeight: gatiTargetHeightRaw,
-      maxWidth,
-    });
-    const metrics = applyTabScaleCompression(rawMetrics, viewportCompression);
-    metricsByTab.set(entry.tab, metrics);
   });
-
-  applyQuadrantTabPositions(quadrantTabs, metricsByTab, geometry);
 }
 
 function resizeCanvas() {

--- a/apps/layakine/index.html
+++ b/apps/layakine/index.html
@@ -168,40 +168,19 @@
       padding: 16px;
     }
     .quadrant-tabs {
-      --quadrant-tab-max-width: none;
-      --quadrant-tab-max-height: none;
-      --quadrant-tab-translate-x: 0px;
-      --quadrant-tab-translate-y: 0px;
-      --quadrant-tab-scale: 1;
-      --quadrant-tab-gap: clamp(2px, 0.8vw, 10px);
-      --quadrant-tab-padding: clamp(3px, 0.6vw, 8px);
       position: absolute;
-      display: inline-flex;
-      flex-wrap: wrap;
-      gap: var(--quadrant-tab-gap);
-      justify-content: center;
-      align-content: center;
-      align-items: center;
+      display: flex;
+      gap: 4px;
+      align-items: stretch;
+      justify-content: flex-start;
       background: rgba(8, 8, 8, 0.85);
       border: 1px solid rgba(255, 255, 255, 0.08);
-      border-radius: 999px;
-      padding: var(--quadrant-tab-padding);
+      border-radius: 10px;
+      padding: 4px;
       z-index: 3;
       box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
       backdrop-filter: blur(6px);
-      max-width: var(--quadrant-tab-max-width, none);
-      max-height: var(--quadrant-tab-max-height, none);
-      transform: translate(var(--quadrant-tab-translate-x), var(--quadrant-tab-translate-y))
-        scale(var(--quadrant-tab-scale));
-      will-change: transform;
-    }
-    .quadrant-tabs[data-quadrant='gati'],
-    .quadrant-tabs[data-quadrant='laya'] {
-      transform-origin: top left;
-    }
-    .quadrant-tabs[data-quadrant='jati'],
-    .quadrant-tabs[data-quadrant='nadai'] {
-      transform-origin: top right;
+      height: var(--quadrant-tab-height, 40px);
     }
     .quadrant-option {
       position: absolute;
@@ -241,11 +220,16 @@
       font-size: clamp(0.62rem, 0.54rem + 0.28vw, 0.95rem);
       font-weight: 600;
       letter-spacing: 0.08em;
-      padding: clamp(4px, 0.4vw + 2px, 10px) clamp(8px, 0.8vw + 6px, 18px);
-      border-radius: 999px;
+      padding: 0;
+      border-radius: 6px;
       cursor: pointer;
       transition: color 0.2s ease, background 0.2s ease;
-      min-width: clamp(40px, 6vw, 80px);
+      flex: 0 0 auto;
+      width: var(--quadrant-tab-width, 80px);
+      height: 100%;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
     }
     .quadrant-tabs button.active {
       background: rgba(244, 244, 244, 0.9);
@@ -256,27 +240,25 @@
       outline-offset: 2px;
     }
     .quadrant-tabs.top-left {
-      top: 24px;
-      left: 24px;
+      top: 0;
+      left: 0;
     }
     .quadrant-tabs.top-right {
-      top: 24px;
-      right: 24px;
-      left: auto;
+      top: 0;
+      left: 50%;
     }
     .quadrant-option.top-right {
-      top: 80px;
+      top: calc(var(--quadrant-tab-height, 40px) + 32px);
       right: 28px;
       left: auto;
     }
     .quadrant-tabs.bottom-left {
-      top: calc(50% + 24px);
-      left: 24px;
+      top: 50%;
+      left: 0;
     }
     .quadrant-tabs.bottom-right {
-      top: calc(50% + 24px);
-      right: 24px;
-      left: auto;
+      top: 50%;
+      left: 50%;
     }
     canvas {
       width: 100%;
@@ -366,37 +348,16 @@
         min-height: 50vh;
       }
       .quadrant-tabs {
-        top: auto;
-        left: auto;
-        --quadrant-tab-gap: clamp(2px, 1.4vw, 6px);
-        --quadrant-tab-padding: clamp(2px, 0.9vw, 6px);
-      }
-      .quadrant-tabs.top-left {
-        top: 16px;
-        left: 16px;
-      }
-      .quadrant-tabs.top-right {
-        top: 16px;
-        right: 12px;
-        left: auto;
+        gap: 3px;
+        padding: 3px;
       }
       .quadrant-tabs button {
         font-size: clamp(0.52rem, 0.48rem + 0.36vw, 0.78rem);
-        padding: clamp(3px, 0.36vw + 2px, 6px) clamp(6px, 0.9vw + 3px, 12px);
-        min-width: clamp(32px, 10vw, 60px);
+        border-radius: 4px;
       }
       .quadrant-option.top-right {
-        top: 68px;
+        top: calc(var(--quadrant-tab-height, 40px) + 24px);
         right: 16px;
-        left: auto;
-      }
-      .quadrant-tabs.bottom-left {
-        top: calc(50% + 12px);
-        left: 16px;
-      }
-      .quadrant-tabs.bottom-right {
-        top: calc(50% + 12px);
-        right: 12px;
         left: auto;
       }
     }


### PR DESCRIPTION
## Summary
- replace the complex positioning logic for Layakine quadrant tabs with a simple, responsive layout tied to quadrant dimensions
- remove the JavaScript measurement helpers in favour of straightforward viewport-derived sizing values
- update the CSS to position each tab group at the top-left of its quadrant and size buttons using the new proportional rules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df8a25f7108320b7f4bfcc9fd471f4