### PR TITLE
Hide unavailable mode options in Layakine quadrants

### DIFF
--- a/apps/layakine/index.html
+++ b/apps/layakine/index.html
@@ -392,17 +392,11 @@
       <div class="quadrant-tabs top-left" data-quadrant="gati">
         <button class="mode-tab" data-quadrant="gati" data-mode="1d" type="button">1D</button>
         <button class="mode-tab" data-quadrant="gati" data-mode="2d" type="button">2D</button>
-        <button class="mode-tab" data-quadrant="gati" data-mode="3d" type="button">3D</button>
       </div>
       <div class="quadrant-tabs top-right" data-quadrant="jati">
         <button class="mode-tab" data-quadrant="jati" data-mode="1d" type="button">1D</button>
         <button class="mode-tab" data-quadrant="jati" data-mode="2d" type="button">2D</button>
         <button class="mode-tab" data-quadrant="jati" data-mode="3d" type="button">3D</button>
-      </div>
-      <div class="quadrant-tabs bottom-left" data-quadrant="laya">
-        <button class="mode-tab" data-quadrant="laya" data-mode="1d" type="button">1D</button>
-        <button class="mode-tab" data-quadrant="laya" data-mode="2d" type="button">2D</button>
-        <button class="mode-tab" data-quadrant="laya" data-mode="3d" type="button">3D</button>
       </div>
       <div class="quadrant-tabs bottom-right" data-quadrant="nadai">
         <button class="mode-tab" data-quadrant="nadai" data-mode="1d" type="button">1D</button>


### PR DESCRIPTION
## Summary
- remove the laya quadrant mode switcher since alternate views are unavailable
- hide the gati quadrant's 3D mode button to prevent selecting an unsupported view

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfbbdb95788320be3f5bd5cdd1ca2f