### PR TITLE
Improve Pralaya play toggle styling

### DIFF
--- a/apps/pralaya/app.js
+++ b/apps/pralaya/app.js
@@ -250,6 +250,13 @@ function render() {
   requestAnimationFrame(render);
 }
 
+function updatePlayToggle() {
+  const isPlaying = Boolean(audioEngine && audioEngine.isPlaying());
+  playToggle.dataset.state = isPlaying ? 'pause' : 'play';
+  playToggle.setAttribute('aria-label', isPlaying ? 'Pause' : 'Play');
+  playToggle.setAttribute('aria-pressed', isPlaying ? 'true' : 'false');
+}
+
 function togglePlay() {
   if (!audioEngine) {
     return;
@@ -259,7 +266,7 @@ function togglePlay() {
   } else {
     audioEngine.start();
   }
-  playToggle.textContent = audioEngine.isPlaying() ? '⏸' : '▶';
+  updatePlayToggle();
 }
 
 playToggle.addEventListener('click', () => {
@@ -321,4 +328,5 @@ audioEngine.setTempo(initialTempo);
 audioEngine.setCounts(initialCounts);
 
 updateValueLabels(sliders, valueLabels, { laya: formatLayaValue });
+updatePlayToggle();
 requestAnimationFrame(render);

--- a/apps/pralaya/index.html
+++ b/apps/pralaya/index.html
@@ -283,12 +283,45 @@
       background: rgba(20, 20, 20, 0.85);
       color: #f7f7f7;
       font-size: 1.4rem;
+      padding: 0;
       cursor: pointer;
       display: flex;
       align-items: center;
       justify-content: center;
       transition: background 0.2s ease;
       z-index: 4;
+    }
+    #play-toggle .play-toggle-icon {
+      width: 28px;
+      height: 28px;
+      display: block;
+      position: relative;
+      background: currentColor;
+      clip-path: polygon(24% 16%, 24% 84%, 78% 50%);
+      transition: transform 0.2s ease, clip-path 0.2s ease;
+    }
+    #play-toggle[data-state='pause'] .play-toggle-icon {
+      background: none;
+      clip-path: none;
+    }
+    #play-toggle[data-state='pause'] .play-toggle-icon::before,
+    #play-toggle[data-state='pause'] .play-toggle-icon::after {
+      content: '';
+      position: absolute;
+      top: 16%;
+      bottom: 16%;
+      width: 26%;
+      border-radius: 1.5px;
+      background: currentColor;
+    }
+    #play-toggle[data-state='pause'] .play-toggle-icon::before {
+      left: 18%;
+    }
+    #play-toggle[data-state='pause'] .play-toggle-icon::after {
+      right: 18%;
+    }
+    #play-toggle:active .play-toggle-icon {
+      transform: scale(0.9);
     }
     #play-toggle:hover {
       background: rgba(40, 40, 40, 0.85);
@@ -404,7 +437,9 @@
         <button class="mode-tab" data-quadrant="nadai" data-mode="3d" type="button">3D</button>
       </div>
       <canvas id="pralaya-canvas" width="800" height="800" aria-hidden="true"></canvas>
-      <button id="play-toggle" type="button" aria-label="Play">▶</button>
+      <button id="play-toggle" type="button" aria-label="Play" data-state="play">
+        <span class="play-toggle-icon" aria-hidden="true"></span>
+      </button>
     </div>
     <section class="control-strip" aria-label="Laya and Nadai controls">
       <div class="control" data-kind="laya">


### PR DESCRIPTION
## Summary
- replace the Pralaya play/pause toggle text with a styled icon to avoid the emoji pause glyph on mobile
- update the toggle logic to manage aria attributes and reflect the current play state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfc36e91788320afee45b8bd806e04